### PR TITLE
task-03 implement lhs sampler

### DIFF
--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
+from .sampling import lhs
 
 __all__ = [
     "__version__",
@@ -10,5 +11,6 @@ __all__ = [
     "DesignPoint",
     "Constraint",
     "OptResult",
+    "lhs",
 ]
 __version__ = "0.0.0"

--- a/src/optilb/sampling/__init__.py
+++ b/src/optilb/sampling/__init__.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import numpy as np
+from scipy.stats import qmc
+
+from ..core import DesignPoint, DesignSpace
+
+
+def lhs(
+    sample_count: int,
+    design_space: DesignSpace,
+    seed: int | None = None,
+    *,
+    centered: bool = False,
+    scramble: bool = True,
+) -> list[DesignPoint]:
+    """Generate Latin-Hypercube samples.
+
+    Parameters
+    ----------
+    sample_count:
+        Number of design points to generate.
+    design_space:
+        Continuous design space describing bounds.
+    seed:
+        Random seed for reproducibility.
+    centered:
+        Place points at the center of each hypercube cell.
+    scramble:
+        Enable scrambling of the unit hypercube.
+
+    Returns
+    -------
+    list[DesignPoint]
+        Generated design points scaled to ``design_space``.
+    """
+    rng = np.random.default_rng(seed)
+
+    if centered:
+        scramble = False
+
+    sampler = qmc.LatinHypercube(d=design_space.dimension, scramble=scramble, rng=rng)
+    sample = sampler.random(n=sample_count)
+    scaled = qmc.scale(sample, design_space.lower, design_space.upper)
+
+    # Round integers if bounds are integers
+    rounded = scaled.copy()
+    for i, (lo, hi) in enumerate(zip(design_space.lower, design_space.upper)):
+        if float(lo).is_integer() and float(hi).is_integer():
+            rounded[:, i] = np.rint(rounded[:, i])
+
+    points = [DesignPoint(x=row) for row in rounded]
+    return points

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optilb import DesignSpace
+from optilb.sampling import lhs
+
+
+def test_lhs_reproducible() -> None:
+    ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+    pts1 = lhs(4, ds, seed=42)
+    pts2 = lhs(4, ds, seed=42)
+    arr1 = np.array([p.x for p in pts1])
+    arr2 = np.array([p.x for p in pts2])
+    np.testing.assert_allclose(arr1, arr2)
+
+
+def test_lhs_with_integer_dimension() -> None:
+    ds = DesignSpace(lower=[0, 0.0], upper=[10, 1.0])
+    pts = lhs(6, ds, seed=123)
+    arr = np.array([p.x for p in pts])
+    assert np.all(arr[:, 0] == np.round(arr[:, 0]))
+    assert np.all(arr[:, 0] >= 0) and np.all(arr[:, 0] <= 10)
+
+
+def test_lhs_centered() -> None:
+    ds = DesignSpace(lower=[0.0], upper=[1.5])
+    pts = lhs(4, ds, centered=True, seed=0)
+    arr = np.array([p.x for p in pts]).flatten()
+    expected = np.array([0.1875, 0.5625, 0.9375, 1.3125])
+    assert np.all(np.isin(arr, expected))


### PR DESCRIPTION
## Summary
- add Latin-Hypercube sampler with optional centred output
- expose `lhs` in package namespace
- test reproducibility, integer rounding and centering behaviour

## Testing
- `isort --profile=black src tests`
- `black src tests -q`
- `flake8 --max-line-length=88 src tests`
- `mypy src/optilb/sampling/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68889e134e548320ae2820a4bcf9e2f3