### PR TITLE
task-03 add markdown docs for LHS

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ Every agent **must also read `ROADMAP.md`** to understand the big‑picture visi
 3. After merging to `main`, CI auto‑builds HTML with `sphinx -W` (warnings as errors) and deploys to GitHub Pages.
 4. Keep `README.md` updated whenever features are added or changed.
 5. For each new functionality, add a dedicated documentation file under `docs/` describing it in detail.
+6. Provide both `.rst` and `.md` versions of each documentation page so that Sphinx and GitHub viewers stay in sync.
+7. Documentation **must** include a short usage snippet so that new tools and agents can replicate the feature easily. Pull requests lacking accompanying docs are rejected.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
 # optilb
 
-**optilb** is an upcoming optimisation toolbox for low-dimensional shape tuning.
-The roadmap outlines a workflow that combines Latin-Hypercube sampling with
-pluggable optimisers (Mesh Adaptive Direct Search via PyNOMAD, SciPy's
-L-BFGS-B and a custom parallel Nelder–Mead).  CFD objectives—from analytic
-toy cases to external executables—will be wrapped through a unified
-`OptimizationProblem` interface.  Optional Gaussian‑Process surrogates and
-robust optimisation utilities are scheduled for later milestones.
+**optilb** is an optimisation toolbox for low-dimensional shape tuning.  The
+roadmap combines Latin-Hypercube sampling with pluggable optimisers (Mesh
+Adaptive Direct Search via PyNOMAD, SciPy's L-BFGS-B and a custom parallel
+Nelder–Mead).  CFD objectives—from analytic toy cases to external executables—are
+wrapped through a unified `OptimizationProblem` interface.  Optional
+Gaussian‑Process surrogates and robust optimisation utilities are scheduled for
+later milestones.
 
-This repository currently contains only the scaffolding, but it will grow as the
-roadmap tasks are tackled.  See `ROADMAP.md` for planned features and progress.
+The current codebase provides the core data classes and a Latin-Hypercube
+sampler.  Below is a minimal example::
+
+    from optilb import DesignSpace
+    from optilb.sampling import lhs
+
+    ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+    points = lhs(4, ds, seed=123)
+    for p in points:
+        print(p.x)
+
+See `ROADMAP.md` for planned features and progress.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+# Documentation Overview
+
+The documentation is written in both reStructuredText (.rst) and Markdown (.md) formats.  Keep both versions in sync when new features are added.
+
+* `sampling.rst` and `sampling.md` cover the Latin-Hypercube sampler.
+* `api/` contains API reference files like `sampling.rst` and `sampling.md`.
+
+The Sphinx build currently uses the `.rst` files, but Markdown copies are provided for quick browsing on GitHub.

--- a/docs/api/sampling.md
+++ b/docs/api/sampling.md
@@ -1,0 +1,15 @@
+# Sampling API
+
+This module exposes the `lhs` function used to create Latin-Hypercube samples.
+
+```python
+from optilb import DesignSpace
+from optilb.sampling import lhs
+
+ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+points = lhs(10, ds, seed=42)
+for p in points:
+    print(p.x)
+```
+
+See the docstring of `lhs` for full parameter information.

--- a/docs/api/sampling.rst
+++ b/docs/api/sampling.rst
@@ -1,0 +1,7 @@
+Sampling API
+============
+
+.. automodule:: optilb.sampling
+    :members: lhs
+    :undoc-members:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,4 +5,6 @@ optilb Documentation
    :maxdepth: 2
    :caption: Contents:
 
+   sampling
+   api/sampling
 

--- a/docs/sampling.md
+++ b/docs/sampling.md
@@ -1,0 +1,15 @@
+# Latin-Hypercube Sampling (LHS)
+
+`optilb` provides a simple function `optilb.sampling.lhs` to generate Latin-Hypercube samples within a given `optilb.DesignSpace`.
+
+```python
+from optilb import DesignSpace
+from optilb.sampling import lhs
+
+ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+points = lhs(10, ds, seed=42)
+for p in points:
+    print(p.x)
+```
+
+The function supports integer bounds, optional scrambling, and centering of points within each hypercube cell.

--- a/docs/sampling.rst
+++ b/docs/sampling.rst
@@ -1,0 +1,19 @@
+Latin-Hypercube Sampling (LHS)
+=============================
+
+``optilb`` provides a simple function :func:`optilb.sampling.lhs` to generate
+Latin-Hypercube samples within a given :class:`optilb.DesignSpace`.
+
+Example usage::
+
+    from optilb import DesignSpace
+    from optilb.sampling import lhs
+
+    ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+    points = lhs(10, ds, seed=42)
+    for p in points:
+        print(p.x)
+
+The function supports integer bounds, optional scrambling, and centering of
+points within each hypercube cell.
+


### PR DESCRIPTION
## Summary
- clarify doc workflow to keep rst and md files in sync
- add Markdown copies of the LHS usage docs
- document API snippet in docs/api

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888a0d04d8883208b805c0c44b6cb62