### PR TITLE
Add analytic toy objectives

### DIFF
--- a/docs/api/objectives.md
+++ b/docs/api/objectives.md
@@ -1,0 +1,12 @@
+# Objectives API
+
+This module exposes simple analytic benchmark functions. Use
+`optilb.get_objective` to obtain them by name.
+
+```python
+from optilb import get_objective
+import numpy as np
+
+rastrigin = get_objective("rastrigin")
+print(rastrigin(np.zeros(2)))  # 0.0
+```

--- a/docs/api/objectives.rst
+++ b/docs/api/objectives.rst
@@ -1,0 +1,6 @@
+Objectives API
+==============
+
+.. automodule:: optilb.objectives
+    :members:
+    :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,5 +6,7 @@ optilb Documentation
    :caption: Contents:
 
    sampling
+   objectives
    api/sampling
+   api/objectives
 

--- a/docs/objectives.md
+++ b/docs/objectives.md
@@ -1,0 +1,15 @@
+# Analytic Objective Functions
+
+`optilb` ships several toy objective functions useful for quick benchmarking.
+They can be obtained via `optilb.get_objective`.
+
+```python
+from optilb import get_objective
+import numpy as np
+
+quad = get_objective("quadratic")
+print(quad(np.array([0.0, 0.0])))  # 0.0
+```
+
+Other available names are `rastrigin`, `noisy_discontinuous` and
+`plateau_cliff`. See the docstrings for details on each function.

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -1,0 +1,16 @@
+Analytic Objective Functions
+===========================
+
+``optilb`` ships several toy objective functions useful for quick benchmarking.
+They are retrieved via :func:`optilb.get_objective`.
+
+Example::
+
+    from optilb import get_objective
+    import numpy as np
+
+    quad = get_objective("quadratic")
+    print(quad(np.array([0.0, 0.0])))  # 0.0
+
+Available names are ``quadratic``, ``rastrigin``, ``noisy_discontinuous`` and
+``plateau_cliff``. See the docstrings for details.

--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
+from .objectives import get_objective
 from .sampling import lhs
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     "Constraint",
     "OptResult",
     "lhs",
+    "get_objective",
 ]
 __version__ = "0.0.0"

--- a/src/optilb/core.py
+++ b/src/optilb/core.py
@@ -43,7 +43,9 @@ class DesignPoint:
 
     x: np.ndarray
     tag: str | None = None
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "x", np.asarray(self.x, dtype=float))
@@ -78,7 +80,8 @@ class OptResult:
     history: Sequence[DesignPoint] = field(default_factory=tuple)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "best_x", np.asarray(self.best_x, dtype=float))
+        arr = np.asarray(self.best_x, dtype=float)
+        object.__setattr__(self, "best_x", arr)
         if not isinstance(self.history, tuple):
             object.__setattr__(self, "history", tuple(self.history))
 

--- a/src/optilb/objectives/__init__.py
+++ b/src/optilb/objectives/__init__.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Callable
+
+import numpy as np
+
+
+def quadratic_bowl(x: np.ndarray) -> float:
+    """Quadratic bowl function.
+
+    Computes ``f(x) = sum(x_i^2)``.
+
+    The global minimum is ``0`` at ``x = 0``.
+
+    Example:
+        >>> quadratic_bowl(np.zeros(2))
+        0.0
+    """
+    x = np.asarray(x, dtype=float)
+    return float(np.sum(x**2))
+
+
+def rastrigin(x: np.ndarray) -> float:
+    """Rastrigin benchmark function.
+
+    Computes ``f(x) = 10 * n + sum(x_i^2 - 10*cos(2*pi*x_i))``.
+
+    The global minimum is ``0`` at ``x = 0``.
+
+    Example:
+        >>> rastrigin(np.zeros(3))
+        0.0
+    """
+    x = np.asarray(x, dtype=float)
+    n = x.size
+    return float(10 * n + np.sum(x**2 - 10 * np.cos(2 * np.pi * x)))
+
+
+def make_noisy_discontinuous(
+    sigma: float = 0.1, *, seed: int | None = None
+) -> Callable[[np.ndarray], float]:
+    """Create a noisy discontinuous objective.
+
+    The base function is ``f(x) = sum(floor(x_i))``. Gaussian noise is added
+    afterwards. The global minimum is ``0`` for ``x`` in ``[0, 1)^n``.
+
+    Args:
+        sigma: Standard deviation of the added Gaussian noise.
+        seed: Optional random seed for reproducibility.
+
+    Example:
+        >>> f = make_noisy_discontinuous(sigma=0.0)
+        >>> f(np.array([0.5, 0.5]))
+        0.0
+    """
+
+    rng = np.random.default_rng(seed)
+
+    def _func(x: np.ndarray) -> float:
+        arr = np.asarray(x, dtype=float)
+        val = float(np.sum(np.floor(arr)))
+        noise = float(rng.normal(0.0, sigma)) if sigma > 0 else 0.0
+        return val + noise
+
+    return _func
+
+
+def plateau_cliff(x: np.ndarray) -> float:
+    """Piecewise plateau with a sharp cliff.
+
+    For ``t = x[0]``::
+
+        f(t) = 1.0                 if t <= 0
+             = 1.0 - t             if 0 < t < 1
+             = 0.0                 if t >= 1
+
+    The global minimum is ``0`` for ``t >= 1``.
+
+    Example:
+        >>> plateau_cliff(np.array([1.5]))
+        0.0
+    """
+    t = float(np.asarray(x, dtype=float)[0])
+    if t <= 0.0:
+        return 1.0
+    if t < 1.0:
+        return 1.0 - t
+    return 0.0
+
+
+Objective = Callable[[np.ndarray], float]
+
+
+def get_objective(name: str, **kwargs) -> Callable[[np.ndarray], float]:
+    """Return an objective function by name.
+
+    Args:
+        name: Identifier of the objective.
+        **kwargs: Parameters passed to the objective factory.
+
+    Returns:
+        Callable[[np.ndarray], float]: Objective function.
+    """
+    key = name.lower()
+    if key == "quadratic":
+        return quadratic_bowl
+    if key == "rastrigin":
+        return rastrigin
+    if key == "noisy_discontinuous":
+        return make_noisy_discontinuous(**kwargs)
+    if key == "plateau_cliff":
+        return plateau_cliff
+    raise ValueError(f"Unknown objective '{name}'")
+
+
+__all__ = [
+    "quadratic_bowl",
+    "rastrigin",
+    "make_noisy_discontinuous",
+    "plateau_cliff",
+    "get_objective",
+]

--- a/src/optilb/sampling/__init__.py
+++ b/src/optilb/sampling/__init__.py
@@ -39,7 +39,9 @@ def lhs(
     if centered:
         scramble = False
 
-    sampler = qmc.LatinHypercube(d=design_space.dimension, scramble=scramble, rng=rng)
+    sampler = qmc.LatinHypercube(
+        d=design_space.dimension, scramble=scramble, rng=rng
+    )
     sample = sampler.random(n=sample_count)
     scaled = qmc.scale(sample, design_space.lower, design_space.upper)
 

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optilb.objectives import (
+    get_objective,
+    make_noisy_discontinuous,
+    plateau_cliff,
+    quadratic_bowl,
+    rastrigin,
+)
+
+
+def test_quadratic_bowl_minimum() -> None:
+    assert quadratic_bowl(np.zeros(3)) == 0.0
+
+
+def test_rastrigin_minimum() -> None:
+    assert rastrigin(np.zeros(4)) == 0.0
+
+
+def test_noisy_discontinuous_zero_noise() -> None:
+    f = make_noisy_discontinuous(sigma=0.0)
+    val = f(np.array([0.2, 0.8]))
+    assert val == 0.0
+
+
+def test_plateau_cliff() -> None:
+    assert plateau_cliff(np.array([1.5])) == 0.0
+    assert plateau_cliff(np.array([-0.5])) == 1.0
+
+
+def test_get_objective_dispatch() -> None:
+    f = get_objective("quadratic")
+    assert f(np.array([0.0])) == 0.0
+    f2 = get_objective("noisy_discontinuous", sigma=0.0)
+    assert f2(np.array([0.3])) == 0.0


### PR DESCRIPTION
## Summary
- implement analytic objective functions and factory
- export `get_objective` from package
- document objectives in docs and API refs
- add corresponding tests
- minor formatting tweaks for flake8

## Testing
- `flake8`
- `mypy --install-types --non-interactive src/optilb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a473fc2883209c9c0d8e857884f6