### PR TITLE
task-05 add lbm stub objective

### DIFF
--- a/docs/api/objectives.md
+++ b/docs/api/objectives.md
@@ -1,7 +1,7 @@
 # Objectives API
 
-This module exposes simple analytic benchmark functions. Use
-`optilb.get_objective` to obtain them by name.
+This module exposes simple analytic benchmark functions plus a lightweight
+``lbm_stub`` surrogate. Use `optilb.get_objective` to obtain them by name.
 
 ```python
 from optilb import get_objective

--- a/docs/objectives.md
+++ b/docs/objectives.md
@@ -11,5 +11,7 @@ quad = get_objective("quadratic")
 print(quad(np.array([0.0, 0.0])))  # 0.0
 ```
 
-Other available names are `rastrigin`, `noisy_discontinuous` and
-`plateau_cliff`. See the docstrings for details on each function.
+Other available names are `rastrigin`, `noisy_discontinuous`, `plateau_cliff`
+and `lbm_stub`. The latter is a purely numerical surrogate for an LBM solver
+and **does not represent real physics**.
+See the docstrings for details on each function.

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -12,5 +12,7 @@ Example::
     quad = get_objective("quadratic")
     print(quad(np.array([0.0, 0.0])))  # 0.0
 
-Available names are ``quadratic``, ``rastrigin``, ``noisy_discontinuous`` and
-``plateau_cliff``. See the docstrings for details.
+Available names are ``quadratic``, ``rastrigin``, ``noisy_discontinuous``,
+``plateau_cliff`` and ``lbm_stub``. The last one is a purely numerical
+surrogate for an LBM solver and **is not physically accurate**.
+See the docstrings for details.

--- a/examples/lbm_stub.py
+++ b/examples/lbm_stub.py
@@ -1,0 +1,32 @@
+"""Visualise the LBM-stub objective.
+
+Run from the repository root with:
+
+    PYTHONPATH=./src python examples/lbm_stub.py
+
+The plot illustrates the pseudo CFD response; it is **not physical**.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from optilb.objectives import get_objective
+
+f = get_objective("lbm_stub")
+
+x = np.linspace(-1.0, 1.0, 50)
+y = np.linspace(-1.0, 1.0, 50)
+X, Y = np.meshgrid(x, y)
+Z = np.empty_like(X)
+for i in range(X.shape[0]):
+    for j in range(X.shape[1]):
+        Z[i, j] = f(np.array([X[i, j], Y[i, j]]))
+
+plt.figure(figsize=(5, 4))
+plt.contourf(X, Y, Z, levels=20)
+plt.xlabel("x1")
+plt.ylabel("x2")
+plt.title("LBM stub objective")
+plt.colorbar(label="cost")
+plt.tight_layout()
+plt.show()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-numpy>=1.24
-scipy>=1.10
+numpy >= 1.24
+scipy >= 1.10
+matplotlib >= 3.7

--- a/src/optilb/objectives/__init__.py
+++ b/src/optilb/objectives/__init__.py
@@ -4,6 +4,8 @@ from typing import Callable
 
 import numpy as np
 
+from .lbm_stub import lbm_stub
+
 
 def quadratic_bowl(x: np.ndarray) -> float:
     """Quadratic bowl function.
@@ -110,6 +112,8 @@ def get_objective(name: str, **kwargs) -> Callable[[np.ndarray], float]:
         return make_noisy_discontinuous(**kwargs)
     if key == "plateau_cliff":
         return plateau_cliff
+    if key in {"lbm", "lbm_stub"}:
+        return lbm_stub
     raise ValueError(f"Unknown objective '{name}'")
 
 
@@ -118,5 +122,6 @@ __all__ = [
     "rastrigin",
     "make_noisy_discontinuous",
     "plateau_cliff",
+    "lbm_stub",
     "get_objective",
 ]

--- a/src/optilb/objectives/lbm_stub.py
+++ b/src/optilb/objectives/lbm_stub.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+from typing import Sequence
+
+import numpy as np
+
+
+def lbm_stub(
+    x: np.ndarray,
+    *,
+    sleep_ms: int = 0,
+    centers: Sequence[float] | None = None,
+    width: float = 0.2,
+) -> float:
+    """Lightweight surrogate for CFD cost.
+
+    This deterministic function mimics a multi-modal CFD response using
+    a sum of shifted Gaussians with additional sinusoidal perturbation.
+
+    Parameters
+    ----------
+    x:
+        Input vector.
+    sleep_ms:
+        Optional artificial delay in milliseconds to emulate wall time.
+    centers:
+        Locations of Gaussian peaks for each dimension.  If ``None``,
+        centers are placed evenly in ``[-0.5, 0.5]``.
+    width:
+        Standard deviation of each Gaussian peak.
+
+    Returns
+    -------
+    float
+        Pseudo CFD objective value.
+    """
+    arr = np.asarray(x, dtype=float)
+    dim = arr.size
+    if centers is None:
+        centers = np.linspace(-0.5, 0.5, dim)
+    centers_arr = np.asarray(list(centers), dtype=float)
+    if centers_arr.size != dim:
+        raise ValueError("Length of centers must match dimension")
+
+    gaussians = np.exp(-((arr - centers_arr) ** 2) / (2 * width**2))
+    value = float(np.sum(gaussians))
+    value += float(0.1 * np.sin(5 * np.sum(arr)))
+
+    if sleep_ms > 0:
+        time.sleep(sleep_ms / 1000.0)
+    return value

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -10,7 +10,9 @@ from optilb import Constraint, DesignPoint, DesignSpace, OptResult
 
 def test_designspace_equality_and_pickle() -> None:
     ds1 = DesignSpace(lower=[0, 0], upper=[1, 1], names=["a", "b"])
-    ds2 = DesignSpace(lower=np.array([0, 0], dtype=float), upper=[1, 1], names=["a", "b"])
+    ds2 = DesignSpace(
+        lower=np.array([0, 0], dtype=float), upper=[1, 1], names=["a", "b"]
+    )
     assert ds1 == ds2
     ds3 = pickle.loads(pickle.dumps(ds1))
     assert ds1 == ds3

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from optilb.objectives import (
     get_objective,
+    lbm_stub,
     make_noisy_discontinuous,
     plateau_cliff,
     quadratic_bowl,
@@ -30,8 +31,16 @@ def test_plateau_cliff() -> None:
     assert plateau_cliff(np.array([-0.5])) == 1.0
 
 
+def test_lbm_stub_deterministic() -> None:
+    val1 = lbm_stub(np.array([0.1, -0.2]))
+    val2 = lbm_stub(np.array([0.1, -0.2]))
+    assert val1 == val2
+
+
 def test_get_objective_dispatch() -> None:
     f = get_objective("quadratic")
     assert f(np.array([0.0])) == 0.0
     f2 = get_objective("noisy_discontinuous", sigma=0.0)
     assert f2(np.array([0.3])) == 0.0
+    f3 = get_objective("lbm_stub")
+    assert f3(np.array([0.1, 0.2])) == lbm_stub(np.array([0.1, 0.2]))


### PR DESCRIPTION
## Summary
- implement a deterministic LBM-stub objective
- expose it via `get_objective`
- document the stub in objectives docs
- add an example script with a plot
- update tests
- add `matplotlib` dependency

## Testing
- `flake8`
- `mypy src tests` *(fails: Found 17 errors in 4 files)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b3def68c832098acba307711a947