### PR TITLE
Add BFGS optimizer

### DIFF
--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -1,12 +1,25 @@
 # Optimizers API
 
-`optilb.optimizers` defines the common `Optimizer` base class that all local search methods implement.
+`optilb.optimizers` defines the common `Optimizer` base class that all local search methods implement.  The toolbox ships a
+`BFGSOptimizer` which wraps SciPy's L‑BFGS‑B algorithm for smooth problems.
 
 ```python
-from optilb.optimizers import Optimizer
+from optilb.optimizers import Optimizer, BFGSOptimizer
 
 class Dummy(Optimizer):
     def optimize(self, objective, x0, space, constraints=(), **kwargs):
         self.record(x0, tag="start")
         return OptResult(best_x=x0, best_f=objective(x0), history=self.history)
 ```
+
+Using the provided `BFGSOptimizer`::
+
+    from optilb import DesignSpace, get_objective
+    from optilb.optimizers import BFGSOptimizer
+    import numpy as np
+
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    opt = BFGSOptimizer()
+    result = opt.optimize(obj, np.array([3.0, -2.0]), ds)
+    print(result.best_x, result.best_f)

--- a/docs/api/optimizers.rst
+++ b/docs/api/optimizers.rst
@@ -2,5 +2,5 @@ Optimizers API
 ==============
 
 .. automodule:: optilb.optimizers
-    :members: Optimizer
+    :members: Optimizer, BFGSOptimizer
     :undoc-members:

--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
 from .objectives import get_objective
-from .optimizers import Optimizer
+from .optimizers import BFGSOptimizer, Optimizer
 from .sampling import lhs
 
 __all__ = [
@@ -14,6 +14,7 @@ __all__ = [
     "Constraint",
     "OptResult",
     "Optimizer",
+    "BFGSOptimizer",
     "lhs",
     "get_objective",
 ]

--- a/src/optilb/optimizers/__init__.py
+++ b/src/optilb/optimizers/__init__.py
@@ -3,5 +3,6 @@
 from __future__ import annotations
 
 from .base import Optimizer
+from .bfgs import BFGSOptimizer
 
-__all__ = ["Optimizer"]
+__all__ = ["Optimizer", "BFGSOptimizer"]

--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import logging
+import numpy as np
+from scipy import optimize
+
+from ..core import Constraint, DesignSpace, OptResult
+from .base import Optimizer
+
+logger = logging.getLogger("optilb")
+
+
+class BFGSOptimizer(Optimizer):
+    """Local optimiser using SciPy's L-BFGS-B algorithm.
+
+    Parameters
+    ----------
+    gradient:
+        Optional function returning the gradient of the objective.  If not
+        provided, numerical differentiation is used.
+    step:
+        Optional finite-difference step used when estimating gradients
+        numerically.
+    """
+
+    def __init__(
+        self,
+        gradient: Callable[[np.ndarray], np.ndarray] | None = None,
+        *,
+        step: float | None = None,
+    ) -> None:
+        super().__init__()
+        self.gradient = gradient
+        self.step = step
+
+    def optimize(
+        self,
+        objective: Callable[[np.ndarray], float],
+        x0: np.ndarray,
+        space: DesignSpace,
+        constraints: Sequence[Constraint] = (),
+        *,
+        max_iter: int = 100,
+        tol: float = 1e-6,
+        seed: int | None = None,
+        parallel: bool = False,
+        verbose: bool = False,
+    ) -> OptResult:
+        """Run the optimiser.
+
+        Parameters match :meth:`Optimizer.optimize`.  Only bound constraints are
+        enforced.
+        """
+        if seed is not None:
+            np.random.default_rng(seed)  # for API symmetry; not used directly
+        x0 = self._validate_x0(x0, space)
+        if constraints:
+            logger.warning(
+                "BFGSOptimizer ignores nonlinear constraints; only bounds are enforced"
+            )
+        self.reset_history()
+        self.record(x0, tag="start")
+
+        bounds = list(zip(space.lower, space.upper))
+
+        jac = self.gradient
+        if jac is None:
+            for attr in ("grad", "gradient", "jac"):
+                maybe = getattr(objective, attr, None)
+                if callable(maybe):
+                    jac = maybe
+                    break
+            else:
+                jac = "3-point"
+
+        options: dict[str, float | int | bool] = {
+            "maxiter": max_iter,
+            "ftol": tol,
+            "gtol": tol,
+            "disp": verbose,
+        }
+        if self.step is not None:
+            options["eps"] = self.step
+
+        def _callback(xk: np.ndarray) -> None:
+            self.record(xk, tag=f"{len(self._history)}")
+
+        try:
+            res = optimize.minimize(
+                objective,
+                x0,
+                method="L-BFGS-B",
+                jac=jac,
+                bounds=bounds,
+                callback=_callback,
+                options=options,
+            )
+        except StopIteration:
+            logger.info("Optimization stopped early by callback")
+            best = self.history[-1].x
+            return OptResult(
+                best_x=best, best_f=float(objective(best)), history=self.history
+            )
+
+        if res.status != 0:
+            logger.warning("SciPy optimisation did not converge: %s", res.message)
+
+        return OptResult(best_x=res.x, best_f=float(res.fun), history=self.history)

--- a/tests/test_optimizer_bfgs.py
+++ b/tests/test_optimizer_bfgs.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import numpy as np
+
+import pytest
+
+from optilb import DesignSpace, get_objective
+from optilb.optimizers import BFGSOptimizer
+
+
+def test_bfgs_quadratic_dims() -> None:
+    for dim in (2, 5):
+        ds = DesignSpace(lower=-5 * np.ones(dim), upper=5 * np.ones(dim))
+        x0 = np.full(dim, 3.0)
+        obj = get_objective("quadratic")
+        opt = BFGSOptimizer()
+        res = opt.optimize(obj, x0, ds, max_iter=50)
+        np.testing.assert_allclose(res.best_x, np.zeros(dim), atol=1e-5)
+        assert res.best_f == pytest.approx(0.0, abs=1e-8)
+        assert len(res.history) >= 1
+
+
+def test_bfgs_rastrigin_origin() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("rastrigin")
+    opt = BFGSOptimizer()
+    res = opt.optimize(obj, np.zeros(2), ds, max_iter=100)
+    np.testing.assert_allclose(res.best_x, np.zeros(2), atol=1e-5)
+    assert res.best_f == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
## Summary
- implement BFGSOptimizer wrapping `scipy.optimize.minimize`
- expose it via `optilb.optimizers` and the package root
- document BFGS usage and API
- test optimisation of quadratic and Rastrigin functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d23ce3108320ae47b20a9cd53bc5