### PR TITLE
task-10 parallel nelder mead

### DIFF
--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -3,7 +3,8 @@
 `optilb.optimizers` defines the common `Optimizer` base class that all local search methods implement.  The toolbox ships a
 `BFGSOptimizer` which wraps SciPy's L‑BFGS‑B algorithm for smooth problems.  A
 `MADSOptimizer` is also available which interfaces with NOMAD's Mesh Adaptive
-Direct Search via the `PyNomadBBO` package.
+Direct Search via the `PyNomadBBO` package.  A parallel `NelderMeadOptimizer`
+provides a derivative‑free alternative.
 
 ```python
 from optilb.optimizers import Optimizer, BFGSOptimizer
@@ -36,4 +37,16 @@ Using the `MADSOptimizer` requires the external `PyNomadBBO` package::
     obj = get_objective("quadratic")
     opt = MADSOptimizer()
     result = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50)
+    print(result.best_x, result.best_f)
+
+Using the `NelderMeadOptimizer` in parallel mode::
+
+    from optilb import DesignSpace, get_objective
+    from optilb.optimizers import NelderMeadOptimizer
+    import numpy as np
+
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    opt = NelderMeadOptimizer()
+    result = opt.optimize(obj, np.array([2.0, -1.0]), ds, parallel=True)
     print(result.best_x, result.best_f)

--- a/docs/api/optimizers.rst
+++ b/docs/api/optimizers.rst
@@ -2,5 +2,5 @@ Optimizers API
 ==============
 
 .. automodule:: optilb.optimizers
-    :members: Optimizer, BFGSOptimizer, MADSOptimizer
+    :members: Optimizer, BFGSOptimizer, MADSOptimizer, NelderMeadOptimizer
     :undoc-members:

--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
 from .objectives import get_objective
-from .optimizers import BFGSOptimizer, MADSOptimizer, Optimizer
+from .optimizers import (
+    BFGSOptimizer,
+    MADSOptimizer,
+    NelderMeadOptimizer,
+    Optimizer,
+)
 from .sampling import lhs
 
 __all__ = [
@@ -16,6 +21,7 @@ __all__ = [
     "Optimizer",
     "BFGSOptimizer",
     "MADSOptimizer",
+    "NelderMeadOptimizer",
     "lhs",
     "get_objective",
 ]

--- a/src/optilb/optimizers/__init__.py
+++ b/src/optilb/optimizers/__init__.py
@@ -5,5 +5,6 @@ from __future__ import annotations
 from .base import Optimizer
 from .bfgs import BFGSOptimizer
 from .mads import MADSOptimizer
+from .nelder_mead import NelderMeadOptimizer
 
-__all__ = ["Optimizer", "BFGSOptimizer", "MADSOptimizer"]
+__all__ = ["Optimizer", "BFGSOptimizer", "MADSOptimizer", "NelderMeadOptimizer"]

--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+import logging
 from typing import Callable, Sequence
 
-import logging
 import numpy as np
 from scipy import optimize
 

--- a/src/optilb/optimizers/mads.py
+++ b/src/optilb/optimizers/mads.py
@@ -7,7 +7,7 @@ import numpy as np
 
 try:
     import PyNomad
-except ImportError as exc:  # pragma: no cover - optional dependency
+except ImportError:  # pragma: no cover - optional dependency
     PyNomad = None  # type: ignore
 
 from ..core import Constraint, DesignSpace, OptResult
@@ -34,7 +34,8 @@ class MADSOptimizer(Optimizer):
     ) -> OptResult:
         if PyNomad is None:
             raise ImportError(
-                "PyNOMAD is not installed; please install PyNomadBBO to use MADSOptimizer"
+                "PyNOMAD is not installed; please install PyNomadBBO to use"
+                " MADSOptimizer"
             )
 
         if seed is not None:

--- a/src/optilb/optimizers/nelder_mead.py
+++ b/src/optilb/optimizers/nelder_mead.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ProcessPoolExecutor
+from functools import partial
+from typing import Callable, Iterable, Sequence
+
+import numpy as np
+
+from ..core import Constraint, DesignSpace, OptResult
+from .base import Optimizer
+
+
+def _evaluate_point(
+    x: np.ndarray,
+    objective: Callable[[np.ndarray], float],
+    lower: np.ndarray,
+    upper: np.ndarray,
+    constraints: Sequence[Constraint],
+    penalty: float,
+) -> float:
+    if np.any(x < lower) or np.any(x > upper):
+        return penalty
+    for c in constraints:
+        val = c(x)
+        if isinstance(val, bool):
+            if not val:
+                return penalty
+        else:
+            if float(val) > 0.0:
+                return penalty
+    return float(objective(x))
+
+
+logger = logging.getLogger("optilb")
+
+
+class NelderMeadOptimizer(Optimizer):
+    """Parallel Nelder–Mead optimiser."""
+
+    def __init__(
+        self,
+        *,
+        step: float | Sequence[float] = 0.5,
+        alpha: float = 1.0,
+        gamma: float = 2.0,
+        beta: float = 0.5,
+        delta: float = 0.5,
+        sigma: float = 0.5,
+        no_improve_thr: float = 1e-6,
+        no_improv_break: int = 10,
+        penalty: float = 1e12,
+        n_workers: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.step = step
+        self.alpha = alpha
+        self.gamma = gamma
+        self.beta = beta
+        self.delta = delta
+        self.sigma = sigma
+        self.no_improve_thr = no_improve_thr
+        self.no_improv_break = no_improv_break
+        self.penalty = penalty
+        self.n_workers = n_workers
+
+    # ------------------------------------------------------------------
+    def _make_penalised(
+        self,
+        objective: Callable[[np.ndarray], float],
+        space: DesignSpace,
+        constraints: Sequence[Constraint],
+    ) -> Callable[[np.ndarray], float]:
+        return partial(
+            _evaluate_point,
+            objective=objective,
+            lower=space.lower,
+            upper=space.upper,
+            constraints=constraints,
+            penalty=self.penalty,
+        )
+
+    def _eval_points(
+        self,
+        func: Callable[[np.ndarray], float],
+        points: Iterable[np.ndarray],
+        executor: ProcessPoolExecutor | None,
+    ) -> list[float]:
+        if executor is None:
+            return [func(p) for p in points]
+        futures = [executor.submit(func, p) for p in points]
+        return [f.result() for f in futures]
+
+    # ------------------------------------------------------------------
+    def optimize(
+        self,
+        objective: Callable[[np.ndarray], float],
+        x0: np.ndarray,
+        space: DesignSpace,
+        constraints: Sequence[Constraint] = (),
+        *,
+        max_iter: int = 100,
+        tol: float = 1e-6,
+        seed: int | None = None,
+        parallel: bool = False,
+        verbose: bool = False,
+    ) -> OptResult:
+        if seed is not None:
+            np.random.default_rng(seed)
+        x0 = self._validate_x0(x0, space)
+        self.reset_history()
+
+        n = space.dimension
+        step = np.asarray(self.step, dtype=float)
+        if step.size == 1:
+            step = np.full(n, float(step))
+        if step.shape != (n,):
+            raise ValueError("step must be scalar or of length equal to dimension")
+
+        penalised = self._make_penalised(objective, space, constraints)
+
+        executor = ProcessPoolExecutor(max_workers=self.n_workers) if parallel else None
+        try:
+            simplex = [x0]
+            for i in range(n):
+                pt = x0.copy()
+                pt[i] += step[i]
+                simplex.append(pt)
+            fvals = self._eval_points(penalised, simplex, executor)
+
+            self.record(simplex[np.argmin(fvals)], tag="start")
+            best = min(fvals)
+            no_improv = 0
+
+            for it in range(max_iter):
+                idx = np.argsort(fvals)
+                simplex = [simplex[i] for i in idx]
+                fvals = [fvals[i] for i in idx]
+                current_best = fvals[0]
+                self.record(simplex[0], tag=str(it))
+                if verbose:
+                    logger.info("%d | best %.6f", it, current_best)
+
+                if best - current_best > tol:
+                    best = current_best
+                    no_improv = 0
+                else:
+                    no_improv += 1
+                if no_improv >= self.no_improv_break:
+                    break
+
+                centroid = np.mean(simplex[:-1], axis=0)
+                worst = simplex[-1]
+
+                # Reflection
+                xr = centroid + self.alpha * (centroid - worst)
+                fr = self._eval_points(penalised, [xr], executor)[0]
+
+                if fvals[0] <= fr < fvals[-2]:
+                    simplex[-1] = xr
+                    fvals[-1] = fr
+                    continue
+
+                if fr < fvals[0]:
+                    xe = centroid + self.gamma * (xr - centroid)
+                    fe = self._eval_points(penalised, [xe], executor)[0]
+                    if fe < fr:
+                        simplex[-1] = xe
+                        fvals[-1] = fe
+                    else:
+                        simplex[-1] = xr
+                        fvals[-1] = fr
+                    continue
+
+                if fvals[-2] <= fr < fvals[-1]:
+                    xoc = centroid + self.beta * (xr - centroid)
+                    foc = self._eval_points(penalised, [xoc], executor)[0]
+                    if foc <= fr:
+                        simplex[-1] = xoc
+                        fvals[-1] = foc
+                        continue
+
+                xic = centroid + self.delta * (worst - centroid)
+                fic = self._eval_points(penalised, [xic], executor)[0]
+                if fic < fvals[-1]:
+                    simplex[-1] = xic
+                    fvals[-1] = fic
+                    continue
+
+                new_points = [simplex[0]]
+                for p in simplex[1:]:
+                    new_points.append(simplex[0] + self.sigma * (p - simplex[0]))
+                new_f = self._eval_points(penalised, new_points[1:], executor)
+                simplex = new_points
+                fvals = [fvals[0]] + list(new_f)
+        finally:
+            if executor is not None:
+                executor.shutdown()
+
+        idx = int(np.argmin(fvals))
+        best_x = simplex[idx]
+        best_f = fvals[idx]
+        return OptResult(best_x=best_x, best_f=float(best_f), history=self.history)

--- a/tests/test_optimizer_bfgs.py
+++ b/tests/test_optimizer_bfgs.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import numpy as np
-
 import pytest
 
 from optilb import DesignSpace, get_objective

--- a/tests/test_optimizer_mads.py
+++ b/tests/test_optimizer_mads.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-pytest.importorskip("PyNomad")
+pytest.importorskip("PyNomad")  # noqa: E402
 
-from optilb import Constraint, DesignSpace, get_objective
-from optilb.optimizers import MADSOptimizer
+from optilb import Constraint, DesignSpace, get_objective  # noqa: E402
+from optilb.optimizers import MADSOptimizer  # noqa: E402
 
 
 def test_mads_quadratic_dims() -> None:
@@ -26,6 +26,12 @@ def test_mads_plateau_cliff_constraint() -> None:
     obj = get_objective("plateau_cliff")
     cons = [Constraint(func=lambda x: x[0] - 0.0, name="x<=0")]
     opt = MADSOptimizer()
-    res = opt.optimize(obj, np.array([-1.0]), ds, constraints=cons, max_iter=50)
+    res = opt.optimize(
+        obj,
+        np.array([-1.0]),
+        ds,
+        constraints=cons,
+        max_iter=50,
+    )
     assert res.best_x[0] <= 0.0
     assert res.best_f == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_optimizer_nelder_mead.py
+++ b/tests/test_optimizer_nelder_mead.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from optilb import Constraint, DesignSpace, get_objective
+from optilb.optimizers import NelderMeadOptimizer
+
+
+def test_nm_quadratic_dims() -> None:
+    for dim in (2, 5):
+        ds = DesignSpace(lower=-5 * np.ones(dim), upper=5 * np.ones(dim))
+        x0 = np.full(dim, 3.0)
+        obj = get_objective("quadratic")
+        opt = NelderMeadOptimizer()
+        res = opt.optimize(obj, x0, ds, max_iter=200)
+        np.testing.assert_allclose(res.best_x, np.zeros(dim), atol=1e-3)
+        assert res.best_f == pytest.approx(0.0, abs=1e-6)
+        assert len(res.history) >= 1
+
+
+def test_nm_plateau_cliff_constraint() -> None:
+    ds = DesignSpace(lower=[-2.0], upper=[2.0])
+    obj = get_objective("plateau_cliff")
+    cons = [Constraint(func=lambda x: x[0] - 0.0, name="x<=0")]
+    opt = NelderMeadOptimizer()
+    res = opt.optimize(obj, np.array([-1.0]), ds, constraints=cons, max_iter=100)
+    assert res.best_x[0] <= 0.0
+    assert res.best_f == pytest.approx(1.0, abs=1e-6)
+
+
+def test_nm_parallel() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    opt = NelderMeadOptimizer()
+    res = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50, parallel=True)
+    np.testing.assert_allclose(res.best_x, np.zeros(2), atol=1e-3)
+    assert res.best_f == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
## Summary
- implement parallel Nelder–Mead optimizer
- expose new optimizer from package and docs
- add tests for Nelder–Mead
- minor style tweaks from linting

## Testing
- `isort --profile black src tests`
- `black -q src tests docs/api`
- `flake8 src tests --max-line-length=88 --extend-ignore=E203`
- `mypy src` *(fails: missing stubs for scipy and others)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888d6c04d5c83208dbe6656736d449a