### PR TITLE
task-00-doc-improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ wrapped through a unified `OptimizationProblem` interface.  Optional
 Gaussian‑Process surrogates and robust optimisation utilities are scheduled for
 later milestones.
 
-To use the MADS optimiser you need the external `PyNomadBBO` package::
+## Installation
+
+`optilb` targets Python 3.10+ and can be installed from source::
+
+    git clone https://github.com/example/optilb.git
+    cd optilb
+    pip install -r requirements.txt
+
+The `PyNomadBBO` package is optional but required for the `MADSOptimizer`::
 
     pip install PyNomadBBO
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,3 +6,7 @@ The documentation is written in both reStructuredText (.rst) and Markdown (.md) 
 * `api/` contains API reference files like `sampling.rst` and `sampling.md`.
 
 The Sphinx build currently uses the `.rst` files, but Markdown copies are provided for quick browsing on GitHub.
+
+To generate the HTML documentation locally::
+
+    sphinx-build -b html docs docs/_build/html


### PR DESCRIPTION
## Summary
- document installation instructions in README
- note how to build docs in docs/README

## Testing
- `isort --check-only src tests`
- `black --check src tests`
- `flake8 --max-line-length=88`
- `mypy --ignore-missing-imports src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888dcd4de14832098f4aa564241fe03