### PR TITLE
task-8 unify optimizer history API

### DIFF
--- a/src/optilb/optimizers/nelder_mead.py
+++ b/src/optilb/optimizers/nelder_mead.py
@@ -111,6 +111,7 @@ class NelderMeadOptimizer(Optimizer):
             np.random.default_rng(seed)
         x0 = self._validate_x0(x0, space)
         self.reset_history()
+        self.record(x0, tag="start")
 
         n = space.dimension
         step = np.asarray(self.step, dtype=float)
@@ -132,7 +133,6 @@ class NelderMeadOptimizer(Optimizer):
                 simplex.append(pt)
             fvals = self._eval_points(penalised, simplex, executor)
 
-            self.record(simplex[np.argmin(fvals)], tag="start")
             best = min(fvals)
             no_improv = 0
 

--- a/tests/test_optimizers_base.py
+++ b/tests/test_optimizers_base.py
@@ -19,6 +19,7 @@ class DummyOptimizer(Optimizer):
         seed: int | None = None,
         parallel: bool = False,
         verbose: bool = False,
+        early_stopper=None,
     ) -> OptResult:
         x0 = self._validate_x0(x0, space)
         self.reset_history()


### PR DESCRIPTION
## Summary
- align `NelderMeadOptimizer` history recording with other optimizers
- keep dummy optimizer signature compatible with base class

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888e60c94a0832083f518bb866f8523