### PR TITLE
task-4-add-noisy-objectives

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ See `ROADMAP.md` for planned features and progress.
 
 - `examples/basic_usage.py` – quick sanity checks.
 - `examples/compare_optimisers.py` – benchmark built-in optimisers on toy objectives.
+- `examples/plot_objectives.py` – visualise 2D objective functions.

--- a/docs/api/objectives.md
+++ b/docs/api/objectives.md
@@ -2,6 +2,8 @@
 
 This module exposes simple analytic benchmark functions plus a lightweight
 ``lbm_stub`` surrogate. Use `optilb.get_objective` to obtain them by name.
+Available names include ``quadratic``, ``rastrigin``, ``noisy_discontinuous``,
+``checkerboard``, ``step_rastrigin``, ``spiky_sine`` and ``lbm_stub``.
 
 ```python
 from optilb import get_objective

--- a/docs/objectives.md
+++ b/docs/objectives.md
@@ -11,7 +11,7 @@ quad = get_objective("quadratic")
 print(quad(np.array([0.0, 0.0])))  # 0.0
 ```
 
-Other available names are `rastrigin`, `noisy_discontinuous`, `plateau_cliff`
-and `lbm_stub`. The latter is a purely numerical surrogate for an LBM solver
+Other available names are `rastrigin`, `noisy_discontinuous`, `checkerboard`,
+`step_rastrigin`, `spiky_sine`, `plateau_cliff` and `lbm_stub`. The latter is a purely numerical surrogate for an LBM solver
 and **does not represent real physics**.
 See the docstrings for details on each function.

--- a/docs/objectives.rst
+++ b/docs/objectives.rst
@@ -13,6 +13,7 @@ Example::
     print(quad(np.array([0.0, 0.0])))  # 0.0
 
 Available names are ``quadratic``, ``rastrigin``, ``noisy_discontinuous``,
-``plateau_cliff`` and ``lbm_stub``. The last one is a purely numerical
+``checkerboard``, ``step_rastrigin``, ``spiky_sine``, ``plateau_cliff`` and
+``lbm_stub``. The last one is a purely numerical
 surrogate for an LBM solver and **is not physically accurate**.
 See the docstrings for details.

--- a/examples/compare_optimisers.py
+++ b/examples/compare_optimisers.py
@@ -31,7 +31,13 @@ def run_benchmark() -> None:
 
     rows: list[dict[str, object]] = []
 
-    objectives = ["quadratic", "rastrigin"]
+    objectives = [
+        "quadratic",
+        "rastrigin",
+        "checkerboard",
+        "step_rastrigin",
+        "spiky_sine",
+    ]
     dims = [2, 3, 5]
 
     for obj_name in objectives:

--- a/examples/plot_objectives.py
+++ b/examples/plot_objectives.py
@@ -1,0 +1,40 @@
+"""Plot 2D objective functions for visual inspection.
+
+Run from the repository root with::
+
+    PYTHONPATH=./src python examples/plot_objectives.py
+"""
+
+from __future__ import annotations
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from optilb import get_objective
+
+OBJECTIVES = [
+    "quadratic",
+    "rastrigin",
+    "noisy_discontinuous",
+    "checkerboard",
+    "step_rastrigin",
+    "lbm_stub",
+]
+
+for name in OBJECTIVES:
+    f = get_objective(name)
+    x = np.linspace(-2.0, 2.0, 50)
+    y = np.linspace(-2.0, 2.0, 50)
+    X, Y = np.meshgrid(x, y)
+    Z = np.empty_like(X)
+    for i in range(X.shape[0]):
+        for j in range(X.shape[1]):
+            Z[i, j] = f(np.array([X[i, j], Y[i, j]]))
+    plt.figure(figsize=(5, 4))
+    plt.contourf(X, Y, Z, levels=20)
+    plt.xlabel("x1")
+    plt.ylabel("x2")
+    plt.title(f"{name} objective")
+    plt.colorbar(label="cost")
+    plt.tight_layout()
+    plt.show()

--- a/src/optilb/sampling/__init__.py
+++ b/src/optilb/sampling/__init__.py
@@ -39,7 +39,7 @@ def lhs(
     if centered:
         scramble = False
 
-    sampler = qmc.LatinHypercube(d=design_space.dimension, scramble=scramble, rng=rng)
+    sampler = qmc.LatinHypercube(d=design_space.dimension, scramble=scramble, seed=rng)
     sample = sampler.random(n=sample_count)
     scaled = qmc.scale(sample, design_space.lower, design_space.upper)
 

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -5,7 +5,10 @@ import numpy as np
 from optilb.objectives import (
     get_objective,
     lbm_stub,
+    make_checkerboard,
     make_noisy_discontinuous,
+    make_spiky_sine,
+    make_step_rastrigin,
     plateau_cliff,
     quadratic_bowl,
     rastrigin,
@@ -37,6 +40,23 @@ def test_lbm_stub_deterministic() -> None:
     assert val1 == val2
 
 
+def test_spiky_sine_repeatable() -> None:
+    f = make_spiky_sine(sigma=0.0)
+    assert f(np.array([0.0])) == f(np.array([0.0]))
+
+
+def test_checkerboard_pattern() -> None:
+    f = make_checkerboard(sigma=0.0)
+    assert f(np.array([0.0, 0.0])) == 0.0
+
+
+def test_step_rastrigin_floor() -> None:
+    f = make_step_rastrigin(sigma=0.0)
+    x = np.array([1.7, -2.3])
+    expected = rastrigin(np.floor(x))
+    assert f(x) == expected
+
+
 def test_get_objective_dispatch() -> None:
     f = get_objective("quadratic")
     assert f(np.array([0.0])) == 0.0
@@ -44,3 +64,6 @@ def test_get_objective_dispatch() -> None:
     assert f2(np.array([0.3])) == 0.0
     f3 = get_objective("lbm_stub")
     assert f3(np.array([0.1, 0.2])) == lbm_stub(np.array([0.1, 0.2]))
+    assert callable(get_objective("spiky_sine"))
+    assert callable(get_objective("checkerboard"))
+    assert callable(get_objective("step_rastrigin"))


### PR DESCRIPTION
## Summary
- add 3 noisy, non-smooth benchmark functions
- update objective factory and docs
- benchmark new objectives in example
- add plotting script for 2D objectives
- fix sampling to use SciPy's `seed` parameter
- extend tests for new objectives

## Testing
- `black --quiet examples tests docs src || true`
- `isort examples tests docs src >/dev/null`
- `mypy src tests >/tmp/mypy.log && tail -n 20 /tmp/mypy.log` *(fails: missing stubs)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888ec7d3fc88320a8956c769f86d356