### PR TITLE
Add evaluation counter for optimizers

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203

--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -33,6 +33,9 @@ Using the provided `BFGSOptimizer`::
     result = opt.optimize(obj, np.array([3.0, -2.0]), ds)
     print(result.best_x, result.best_f)
 
+The returned `OptResult` also records `nfev`, the total number of objective
+function evaluations.
+
 Using the `MADSOptimizer` requires the external `PyNomadBBO` package::
 
     from optilb import DesignSpace, get_objective

--- a/src/optilb/core.py
+++ b/src/optilb/core.py
@@ -76,6 +76,7 @@ class OptResult:
     best_x: np.ndarray
     best_f: float
     history: Sequence[DesignPoint] = field(default_factory=tuple)
+    nfev: int = 0
 
     def __post_init__(self) -> None:
         arr = np.asarray(self.best_x, dtype=float)
@@ -90,4 +91,5 @@ class OptResult:
             np.array_equal(self.best_x, other.best_x)
             and self.best_f == other.best_f
             and self.history == other.history
+            and self.nfev == other.nfev
         )

--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -77,6 +77,8 @@ class BFGSOptimizer(Optimizer):
             else:
                 jac = "3-point"
 
+        objective = self._wrap_objective(objective)
+
         options: dict[str, float | int | bool] = {
             "maxiter": max_iter,
             "ftol": tol,
@@ -110,10 +112,18 @@ class BFGSOptimizer(Optimizer):
             logger.info("Optimization stopped early by callback")
             best = self.history[-1].x
             return OptResult(
-                best_x=best, best_f=float(objective(best)), history=self.history
+                best_x=best,
+                best_f=float(objective(best)),
+                history=self.history,
+                nfev=self.nfev,
             )
 
         if res.status != 0:
             logger.warning("SciPy optimisation did not converge: %s", res.message)
 
-        return OptResult(best_x=res.x, best_f=float(res.fun), history=self.history)
+        return OptResult(
+            best_x=res.x,
+            best_f=float(res.fun),
+            history=self.history,
+            nfev=self.nfev,
+        )

--- a/src/optilb/optimizers/mads.py
+++ b/src/optilb/optimizers/mads.py
@@ -50,6 +50,7 @@ class MADSOptimizer(Optimizer):
             logger.info("Parallel execution is not yet supported; running serially")
 
         x0 = self._validate_x0(x0, space)
+        objective = self._wrap_objective(objective)
         self.reset_history()
         self.record(x0, tag="start")
         if early_stopper is not None:
@@ -104,4 +105,9 @@ class MADSOptimizer(Optimizer):
         )
         best = np.array(res["x_best"], dtype=float)
         best_f = float(res["f_best"])
-        return OptResult(best_x=best, best_f=best_f, history=self.history)
+        return OptResult(
+            best_x=best,
+            best_f=best_f,
+            history=self.history,
+            nfev=self.nfev,
+        )

--- a/src/optilb/optimizers/nelder_mead.py
+++ b/src/optilb/optimizers/nelder_mead.py
@@ -110,6 +110,7 @@ class NelderMeadOptimizer(Optimizer):
         if seed is not None:
             np.random.default_rng(seed)
         x0 = self._validate_x0(x0, space)
+        objective = self._wrap_objective(objective)
         self.reset_history()
         self.record(x0, tag="start")
 
@@ -208,4 +209,9 @@ class NelderMeadOptimizer(Optimizer):
         idx = int(np.argmin(fvals))
         best_x = simplex[idx]
         best_f = fvals[idx]
-        return OptResult(best_x=best_x, best_f=float(best_f), history=self.history)
+        return OptResult(
+            best_x=best_x,
+            best_f=float(best_f),
+            history=self.history,
+            nfev=self.nfev,
+        )

--- a/tests/test_optimizer_bfgs.py
+++ b/tests/test_optimizer_bfgs.py
@@ -38,3 +38,12 @@ def test_bfgs_early_stop_target() -> None:
     )
     assert res.best_f <= 0.5
     assert len(res.history) < 100
+
+
+def test_bfgs_nfev() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    opt = BFGSOptimizer()
+    res = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=10)
+    assert res.nfev == opt.nfev
+    assert res.nfev >= len(res.history)

--- a/tests/test_optimizer_mads.py
+++ b/tests/test_optimizer_mads.py
@@ -35,3 +35,12 @@ def test_mads_plateau_cliff_constraint() -> None:
     )
     assert res.best_x[0] <= 0.0
     assert res.best_f == pytest.approx(1.0, abs=1e-6)
+
+
+def test_mads_nfev() -> None:
+    ds = DesignSpace(lower=[-2.0], upper=[2.0])
+    obj = get_objective("quadratic")
+    opt = MADSOptimizer()
+    res = opt.optimize(obj, np.array([1.0]), ds, max_iter=20)
+    assert res.nfev == opt.nfev
+    assert res.nfev >= len(res.history)

--- a/tests/test_optimizer_nelder_mead.py
+++ b/tests/test_optimizer_nelder_mead.py
@@ -46,3 +46,12 @@ def test_nm_early_stop_plateau() -> None:
     res = opt.optimize(obj, np.array([0.5]), ds, max_iter=50, early_stopper=stopper)
     assert res.best_f == pytest.approx(0.0, abs=1e-6)
     assert len(res.history) < 50
+
+
+def test_nm_nfev() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    opt = NelderMeadOptimizer()
+    res = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=20)
+    assert res.nfev == opt.nfev
+    assert res.nfev >= len(res.history)


### PR DESCRIPTION
## Summary
- extend `OptResult` with `nfev`
- track objective evaluations in `Optimizer`
- expose counts from BFGS/MADS/Nelder-Mead
- document the new field
- test evaluation counting for all optimizers

## Testing
- `flake8`
- `mypy src` *(fails: missing PyNomad stubs and typing for scipy minimize)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f1f003e8832093725589428c1585