### PR TITLE
Improve benchmark table

### DIFF
--- a/examples/compare_optimisers.py
+++ b/examples/compare_optimisers.py
@@ -71,13 +71,15 @@ def run_benchmark() -> None:
                     early_stopper=stopper,
                 )
                 dt = time.perf_counter() - t0
+                optimum_val = get_objective(obj_name, sigma=0.0)(np.zeros(dim))
                 rows.append(
                     {
                         "objective": obj_name,
                         "dim": dim,
                         "optimizer": name,
                         "best_f": res.best_f,
-                        "evals": len(res.history),
+                        "optimum": optimum_val,
+                        "evals": res.nfev,
                         "time_s": dt,
                         "early_stop": stopper._counter >= stopper.patience,
                     }

--- a/src/optilb/optimizers/mads.py
+++ b/src/optilb/optimizers/mads.py
@@ -83,7 +83,6 @@ class MADSOptimizer(Optimizer):
             for g in con_funcs:
                 vals.append(float(g(arr)))
             point.setBBO(" ".join(str(v) for v in vals).encode("utf-8"))
-            self.record(arr, tag=f"{len(self._history)}")
             return 1
 
         output_types = "OBJ" + " PB" * len(con_funcs)


### PR DESCRIPTION
## Summary
- fix function evaluation counting in example benchmark
- record fewer points in MADS so history length is sane

## Testing
- `mypy --ignore-missing-imports examples/compare_optimisers.py`
- `mypy --ignore-missing-imports src/optilb/optimizers/mads.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888f9cd3fa8832093842fe0a3bfeecf