### PR TITLE
Add example for parallel optimisation speed-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ See `ROADMAP.md` for planned features and progress.
 - `examples/basic_usage.py` – quick sanity checks.
 - `examples/compare_optimisers.py` – benchmark built-in optimisers on toy objectives.
 - `examples/plot_objectives.py` – visualise 2D objective functions.
+- `examples/parallel_speedup.py` – demonstrate parallel Nelder–Mead speed-up on a slow objective.

--- a/examples/parallel_speedup.py
+++ b/examples/parallel_speedup.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+from optilb import DesignSpace
+from optilb.objectives import lbm_stub
+from optilb.optimizers import NelderMeadOptimizer
+
+
+def run_demo() -> None:
+    """Compare sequential and parallel Nelder-Mead on an expensive objective."""
+
+    ds = DesignSpace(lower=np.array([-1.0, -1.0]), upper=np.array([1.0, 1.0]))
+    x0 = np.array([0.5, 0.5])
+
+    def slow_obj(x: np.ndarray) -> float:
+        return lbm_stub(x, sleep_ms=50)
+
+    opt = NelderMeadOptimizer(n_workers=4)
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_obj, x0, ds, max_iter=30, parallel=False)
+    t_seq = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_obj, x0, ds, max_iter=30, parallel=True)
+    t_par = time.perf_counter() - t0
+
+    print(f"Sequential time: {t_seq:.2f} s")
+    print(f"Parallel time:   {t_par:.2f} s")
+    if t_par > 0:
+        print(f"Speed-up: {t_seq / t_par:.2f}x")
+
+
+if __name__ == "__main__":
+    run_demo()


### PR DESCRIPTION
## Summary
- add `parallel_speedup.py` demo script
- reference the new example in README

## Testing
- `flake8 examples/parallel_speedup.py`
- `MYPYPATH=src mypy examples/parallel_speedup.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9a68e1a48320b68d5e1f5697326d