### PR TITLE
Fix BFGS early-stop overhead

### DIFF
--- a/src/optilb/optimizers/base.py
+++ b/src/optilb/optimizers/base.py
@@ -14,10 +14,13 @@ from .early_stop import EarlyStopper
 class _CountingFunction:
     func: Callable[[np.ndarray], float]
     optimizer: "Optimizer"
+    last_val: float | None = None
 
     def __call__(self, x: np.ndarray) -> float:
+        val = float(self.func(x))
+        self.last_val = val
         self.optimizer._nfev += 1
-        return float(self.func(x))
+        return val
 
 
 class Optimizer(ABC):
@@ -60,7 +63,7 @@ class Optimizer(ABC):
 
     def _wrap_objective(
         self, objective: Callable[[np.ndarray], float]
-    ) -> Callable[[np.ndarray], float]:
+    ) -> _CountingFunction:
         """Return objective wrapper that increments the evaluation counter."""
 
         return _CountingFunction(func=objective, optimizer=self)


### PR DESCRIPTION
## Summary
- reduce double objective calls in `BFGSOptimizer`
- track last evaluation in `_CountingFunction`

## Testing
- `flake8 src/optilb/optimizers/base.py src/optilb/optimizers/bfgs.py`
- `mypy src/optilb/optimizers/base.py src/optilb/optimizers/bfgs.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688be1d575a88320a1e1dde074e0e15a