### PR TITLE
Fix bugs in Nelder-Mead optimizer

### DIFF
--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -63,3 +63,7 @@ Using the `NelderMeadOptimizer` in parallel mode::
 The objective function must be picklable when using ``parallel=True``.
 Expect identical numerical results, though start-up overhead means
 parallel execution benefits only expensive objectives.
+
+Setting ``normalize=True`` runs the algorithm in the unit cube and
+scales the inputs/outputs back afterwards.  This makes the default step
+size independent of the original parameter ranges.

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -8,8 +8,8 @@ It should execute without printing anything if all assertions pass.
 """
 
 from optilb.core import DesignPoint, DesignSpace
-from optilb.sampling import lhs
 from optilb.objectives import get_objective
+from optilb.sampling import lhs
 
 # --- core dataclasses -------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,4 @@ extend-ignore = ["E203"]
 [tool.mypy]
 python_version = "3.10"
 check_untyped_defs = true
+ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- fix unused variables and long lines in `NelderMeadOptimizer`
- annotate optional variables for mypy
- reformat basic usage example
- configure mypy to ignore missing third‑party stubs
- document `normalize` flag in optimizer docs

## Testing
- `black .`
- `isort --check examples/basic_usage.py`
- `flake8`
- `mypy src/optilb`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ca33e98f08320949d9c0f471d766d