### PR TITLE
Enable threaded evaluation for NOMAD MADS optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ The `PyNomadBBO` package is optional but required for the `MADSOptimizer`::
 
     pip install PyNomadBBO
 
+To enable parallel evaluation of NOMAD trial points, construct the optimiser
+with a desired worker count and set ``parallel=True`` when calling
+``optimize``::
+
+    from optilb.optimizers import MADSOptimizer
+    opt = MADSOptimizer(n_workers=4)
+    result = opt.optimize(obj, x0, ds, parallel=True)
+
 The current codebase provides the core data classes and a Latin-Hypercube
 sampler.  Below is a minimal example::
 

--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -8,12 +8,13 @@ provides a derivative‑free alternative.  For additional control over run time,
 you can supply an `EarlyStopper` instance that halts the optimisation when no
 progress is seen::
 
-    from optilb.optimizers import NelderMeadOptimizer, EarlyStopper
+    from optilb.optimizers import EarlyStopper, NelderMeadOptimizer
     stopper = EarlyStopper(patience=5, eps=0.0)
     result = NelderMeadOptimizer().optimize(obj, x0, ds, early_stopper=stopper)
 
 ```python
-from optilb.optimizers import Optimizer, BFGSOptimizer
+from optilb.optimizers import BFGSOptimizer, Optimizer
+
 
 class Dummy(Optimizer):
     def optimize(self, objective, x0, space, constraints=(), **kwargs):
@@ -23,9 +24,10 @@ class Dummy(Optimizer):
 
 Using the provided `BFGSOptimizer`::
 
+    import numpy as np
+
     from optilb import DesignSpace, get_objective
     from optilb.optimizers import BFGSOptimizer
-    import numpy as np
 
     ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
     obj = get_objective("quadratic")
@@ -38,9 +40,10 @@ function evaluations.
 
 Using the `MADSOptimizer` requires the external `PyNomadBBO` package::
 
+    import numpy as np
+
     from optilb import DesignSpace, get_objective
     from optilb.optimizers import MADSOptimizer
-    import numpy as np
 
     ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
     obj = get_objective("quadratic")
@@ -48,11 +51,18 @@ Using the `MADSOptimizer` requires the external `PyNomadBBO` package::
     result = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50)
     print(result.best_x, result.best_f)
 
+To evaluate poll/search points concurrently, construct the optimiser with a
+desired worker count and pass ``parallel=True``::
+
+    opt = MADSOptimizer(n_workers=4)
+    result = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50, parallel=True)
+
 Using the `NelderMeadOptimizer` in parallel mode::
+
+    import numpy as np
 
     from optilb import DesignSpace, get_objective
     from optilb.optimizers import NelderMeadOptimizer
-    import numpy as np
 
     ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
     obj = get_objective("quadratic")

--- a/tests/test_optimizer_mads_parallel.py
+++ b/tests/test_optimizer_mads_parallel.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from optilb import DesignSpace
+from optilb.optimizers import MADSOptimizer
+
+
+def slow_obj(x: np.ndarray) -> float:
+    time.sleep(0.25)
+    return float(np.sum(x**2))
+
+
+@pytest.mark.skipif(
+    pytest.importorskip("nomad", reason="PyNOMAD not installed") is None,
+    reason="PyNOMAD not installed",
+)
+def test_mads_parallel_speed():
+    ds = DesignSpace(lower=-1 * np.ones(3), upper=np.ones(3))
+    x0 = np.full(3, 0.5)
+
+    opt = MADSOptimizer(n_workers=4)
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_obj, x0, ds, max_iter=60, parallel=False)
+    t_seq = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_obj, x0, ds, max_iter=60, parallel=True)
+    t_par = time.perf_counter() - t0
+
+    # Allow some slack, but expect meaningful improvement for multi-eval steps
+    assert (
+        t_par < t_seq * 0.8 or (t_seq - t_par) > 2.0
+    )  # either 20% faster or >2s saved
+
+
+def test_mads_api_parallel_flag_doesnt_break_seq():
+    ds = DesignSpace(lower=np.array([-2.0, -2.0]), upper=np.array([2.0, 2.0]))
+    x0 = np.array([1.0, 1.0])
+
+    opt = MADSOptimizer()
+    res_seq = opt.optimize(
+        lambda x: float(np.sum(x**2)), x0, ds, max_iter=50, parallel=False
+    )
+    res_par = opt.optimize(
+        lambda x: float(np.sum(x**2)), x0, ds, max_iter=50, parallel=True
+    )
+
+    assert res_seq.best_f == pytest.approx(res_par.best_f, rel=1e-6, abs=1e-8)


### PR DESCRIPTION
## Summary
- allow MADSOptimizer to run NOMAD evaluations in parallel via `NB_THREADS_PARALLEL_EVAL`
- document `parallel=True`/`n_workers` usage in docs and README
- add regression tests for threaded MADS behavior

## Testing
- `flake8 src/optilb/optimizers/mads.py tests/test_optimizer_mads_parallel.py`
- `mypy src/optilb/optimizers/mads.py tests/test_optimizer_mads_parallel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e2321e5bc8320afc4bea3b30cc53d