### PR TITLE
feat: enable finite difference gradients in BFGS

### DIFF
--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -1,6 +1,19 @@
 from __future__ import annotations
 
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+
+try:  # nullcontext for py<3.7
+    from contextlib import nullcontext  # type: ignore[attr-defined]
+except Exception:
+    from contextlib import contextmanager
+
+    @contextmanager
+    def nullcontext():
+        yield
+
+
 from typing import Callable, Sequence, cast
 
 import numpy as np
@@ -12,6 +25,10 @@ from .early_stop import EarlyStopper
 
 logger = logging.getLogger("optilb")
 
+# NOTE: We intentionally do NOT define nested wrappers for the objective here.
+# In parallel mode we use ThreadPoolExecutor and call the optimizer's
+# wrapped objective directly to preserve nfev/penalties and avoid pickling issues.
+
 
 class BFGSOptimizer(Optimizer):
     """Local optimiser using SciPy's L-BFGS-B algorithm.
@@ -19,11 +36,18 @@ class BFGSOptimizer(Optimizer):
     Parameters
     ----------
     gradient:
-        Optional function returning the gradient of the objective.  If not
+        Optional function returning the gradient of the objective. If not
         provided, numerical differentiation is used.
     step:
-        Optional finite-difference step used when estimating gradients
-        numerically.
+        Legacy alias for ``fd_eps``. If ``fd_eps`` is not given, ``step`` is
+        used as the finite-difference step for numerical gradients.
+    fd_eps:
+        Finite-difference step size(s) used when estimating gradients
+        numerically. May be a scalar or an array with one entry per design
+        dimension. When ``None`` (default), a value of ``1e-6`` is used.
+    n_workers:
+        Maximum number of worker threads used when ``parallel=True`` during
+        numerical gradient evaluation.
     """
 
     def __init__(
@@ -31,10 +55,14 @@ class BFGSOptimizer(Optimizer):
         gradient: Callable[[np.ndarray], np.ndarray] | None = None,
         *,
         step: float | None = None,
+        fd_eps: float | Sequence[float] | None = None,
+        n_workers: int | None = None,
     ) -> None:
         super().__init__()
         self.gradient = gradient
         self.step = step
+        self.fd_eps = fd_eps
+        self.n_workers = n_workers
 
     def optimize(
         self,
@@ -52,7 +80,7 @@ class BFGSOptimizer(Optimizer):
     ) -> OptResult:
         """Run the optimiser.
 
-        Parameters match :meth:`Optimizer.optimize`.  Only bound constraints are
+        Parameters match :meth:`Optimizer.optimize`. Only bound constraints are
         enforced.
         """
         if seed is not None:
@@ -67,15 +95,13 @@ class BFGSOptimizer(Optimizer):
 
         bounds = list(zip(space.lower, space.upper))
 
-        jac: Callable[[np.ndarray], np.ndarray] | str | None = self.gradient
+        jac: Callable[[np.ndarray], np.ndarray] | None = self.gradient
         if jac is None:
             for attr in ("grad", "gradient", "jac"):
                 maybe = getattr(objective, attr, None)
                 if callable(maybe):
                     jac = maybe
                     break
-            else:
-                jac = "3-point"
 
         wrapped_obj = self._wrap_objective(objective)
 
@@ -85,8 +111,6 @@ class BFGSOptimizer(Optimizer):
             "gtol": tol,
             "disp": verbose,
         }
-        if self.step is not None:
-            options["eps"] = self.step
 
         if early_stopper is not None:
             early_stopper.reset()
@@ -94,22 +118,105 @@ class BFGSOptimizer(Optimizer):
         def _callback(xk: np.ndarray) -> None:
             self.record(xk, tag=f"{len(self._history)}")
             if early_stopper is not None:
-                f_val = wrapped_obj.last_val
-                if f_val is None:
-                    f_val = float(wrapped_obj(xk))
+                # Always recompute f(xk) to avoid races with threaded FD evals
+                f_val = float(wrapped_obj(xk))
                 if early_stopper.update(f_val):
                     raise StopIteration
 
+        # ------------------------------------------------------------------
+        # Numerical gradient setup (central differences with bounds handling)
+        # ------------------------------------------------------------------
+        use_central = False
+        _executor = None  # type: ignore[assignment]
+        if jac is None:
+            fd_eps = self.fd_eps
+            if fd_eps is None and self.step is not None:
+                fd_eps = self.step
+
+            n = space.dimension
+            if fd_eps is None:
+                eps_vec = np.full(n, 1e-6, dtype=float)
+            else:
+                eps_vec = np.asarray(fd_eps, dtype=float)
+                if eps_vec.ndim == 0:
+                    eps_vec = np.full(n, float(eps_vec), dtype=float)
+                elif eps_vec.shape != (n,):
+                    raise ValueError("fd_eps must be scalar or match dimension")
+
+            lower = np.asarray(space.lower, dtype=float)
+            upper = np.asarray(space.upper, dtype=float)
+
+            def _central_grad(x: np.ndarray) -> np.ndarray:
+                x = np.asarray(x, dtype=float)
+                n_dim = x.size
+                grads = np.empty(n_dim, dtype=float)
+
+                plus_pts: list[np.ndarray] = []
+                minus_pts: list[np.ndarray] = []
+                h_plus = np.empty(n_dim, dtype=float)
+                h_minus = np.empty(n_dim, dtype=float)
+
+                for i in range(n_dim):
+                    h = eps_vec[i]
+                    hp = min(h, upper[i] - x[i])
+                    hm = min(h, x[i] - lower[i])
+                    hp = 0.0 if hp < 0.0 else hp
+                    hm = 0.0 if hm < 0.0 else hm
+                    h_plus[i] = hp
+                    h_minus[i] = hm
+
+                    xp = x.copy()
+                    xm = x.copy()
+                    xp[i] += hp
+                    xm[i] -= hm
+                    plus_pts.append(xp)
+                    minus_pts.append(xm)
+
+                if _executor is not None:
+                    f_plus = list(_executor.map(wrapped_obj, plus_pts))
+                    f_minus = list(_executor.map(wrapped_obj, minus_pts))
+                else:
+                    f_plus = [float(wrapped_obj(z)) for z in plus_pts]
+                    f_minus = [float(wrapped_obj(z)) for z in minus_pts]
+
+                f0_cache: float | None = None
+                for i in range(n_dim):
+                    hp = h_plus[i]
+                    hm = h_minus[i]
+                    if hp > 0.0 and hm > 0.0:
+                        grads[i] = (f_plus[i] - f_minus[i]) / (hp + hm)
+                    elif hp > 0.0:
+                        if f0_cache is None:
+                            f0_cache = float(wrapped_obj(x))
+                        grads[i] = (f_plus[i] - f0_cache) / hp
+                    elif hm > 0.0:
+                        if f0_cache is None:
+                            f0_cache = float(wrapped_obj(x))
+                        grads[i] = (f0_cache - f_minus[i]) / hm
+                    else:
+                        grads[i] = 0.0
+                return grads
+
+            jac = _central_grad
+            use_central = True
+
+        # ------------------------- optimisation --------------------------
         try:
-            res = optimize.minimize(  # type: ignore[call-overload]
-                cast(Callable[[np.ndarray], float], wrapped_obj),
-                x0,
-                method="L-BFGS-B",
-                jac=jac,
-                bounds=bounds,
-                callback=_callback,
-                options=options,
-            )
+            # Decide worker count: default to all cores when parallel+central FD
+            _need_pool = bool(parallel and use_central)
+            _workers = (self.n_workers or os.cpu_count() or 1) if _need_pool else None
+            with (
+                ThreadPoolExecutor(max_workers=_workers) if _workers else nullcontext()
+            ) as _executor:
+                res = optimize.minimize(  # type: ignore[call-overload]
+                    cast(Callable[[np.ndarray], float], wrapped_obj),
+                    x0,
+                    method="L-BFGS-B",
+                    jac=jac,
+                    bounds=bounds,
+                    callback=_callback,
+                    options=options,
+                )
         except StopIteration:
             logger.info("Optimization stopped early by callback")
             best = self.history[-1].x

--- a/tests/test_optimizer_bfgs_fd.py
+++ b/tests/test_optimizer_bfgs_fd.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+
+import numpy as np
+import pytest
+
+from optilb import DesignSpace
+from optilb.optimizers import BFGSOptimizer
+
+
+def quadratic(x: np.ndarray) -> float:
+    return float(np.sum((x - 1.0) ** 2))
+
+
+def slow_quadratic(x: np.ndarray) -> float:
+    time.sleep(0.05)
+    return quadratic(x)
+
+
+def test_bfgs_fd_scalar_eps() -> None:
+    ds = DesignSpace(lower=-5 * np.ones(3), upper=5 * np.ones(3))
+    x0 = np.array([2.5, -1.0, 0.0])
+    opt = BFGSOptimizer(fd_eps=1e-6)
+    res = opt.optimize(quadratic, x0, ds, max_iter=200, parallel=False)
+    np.testing.assert_allclose(res.best_x, np.ones(3), atol=1e-3)
+    assert res.best_f == pytest.approx(0.0, abs=1e-6)
+
+
+def test_bfgs_fd_array_eps() -> None:
+    ds = DesignSpace(lower=-5 * np.ones(2), upper=5 * np.ones(2))
+    x0 = np.array([3.0, -2.0])
+    opt = BFGSOptimizer(fd_eps=[1e-6, 1e-8])
+    res = opt.optimize(quadratic, x0, ds, max_iter=200, parallel=False)
+    np.testing.assert_allclose(res.best_x, np.ones(2), atol=1e-3)
+    assert res.best_f == pytest.approx(0.0, abs=1e-6)
+
+
+def test_bfgs_fd_parallel_speed() -> None:
+    ds = DesignSpace(lower=-5 * np.ones(6), upper=5 * np.ones(6))
+    x0 = np.full(6, 2.0)
+    opt = BFGSOptimizer(fd_eps=1e-5, n_workers=6)
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_quadratic, x0, ds, max_iter=5, parallel=False)
+    t_seq = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    opt.optimize(slow_quadratic, x0, ds, max_iter=5, parallel=True)
+    t_par = time.perf_counter() - t0
+
+    assert t_par < t_seq


### PR DESCRIPTION
## Summary
- extend BFGS optimizer with configurable finite-difference `fd_eps` and optional parallel workers
- compute explicit central-difference gradients when no analytic Jacobian is provided
- test scalar/array `fd_eps` and parallel gradient evaluation

## Testing
- `black src/optilb/optimizers/bfgs.py tests/test_optimizer_bfgs_fd.py`
- `isort src/optilb/optimizers/bfgs.py tests/test_optimizer_bfgs_fd.py`
- `flake8`
- `mypy .` *(fails: Argument "upper" to "DesignSpace" has incompatible type "list[float]"; expected "ndarray[tuple[Any, ...], dtype[Any]]"  [arg-type])* 
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688e2c300d6883209430d0e2c6387e09