### PR TITLE
Refactor Latin Hypercube RNG usage and cleanup unused alias

### DIFF
--- a/src/optilb/objectives/__init__.py
+++ b/src/optilb/objectives/__init__.py
@@ -160,9 +160,6 @@ def make_step_rastrigin(
     return _StepRastrigin(sigma=sigma, seed=seed)
 
 
-Objective = Callable[[np.ndarray], float]
-
-
 def get_objective(name: str, **kwargs) -> Callable[[np.ndarray], float]:
     """Return an objective function by name.
 

--- a/src/optilb/sampling/__init__.py
+++ b/src/optilb/sampling/__init__.py
@@ -39,7 +39,11 @@ def lhs(
     if centered:
         scramble = False
 
-    sampler = qmc.LatinHypercube(d=design_space.dimension, scramble=scramble, seed=rng)
+    sampler = qmc.LatinHypercube(
+        d=design_space.dimension,
+        scramble=scramble,
+        rng=rng,
+    )
     sample = sampler.random(n=sample_count)
     scaled = qmc.scale(sample, design_space.lower, design_space.upper)
 


### PR DESCRIPTION
## Summary
- ensure Latin hypercube sampling forwards RNG via `rng` argument for reproducible draws
- drop unused `Objective` alias in objectives module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688e36db4b248320b9868e0306a9cbc9