### PR TITLE
feat: show start and end coordinates in slow objective comparison

### DIFF
--- a/examples/slow_objective_comparison.py
+++ b/examples/slow_objective_comparison.py
@@ -109,7 +109,9 @@ def run_comparison() -> None:
             rows.append(
                 {
                     "init_idx": idx,
+                    "init_x": x0.tolist(),
                     "optimizer": name,
+                    "best_x": res.best_x.tolist(),
                     "best_f": res.best_f,
                     "optimum": OPTIMUM,
                     "evals": res.nfev,


### PR DESCRIPTION
## Summary
- include starting and final coordinates in slow objective comparison output table

## Testing
- `flake8 examples/slow_objective_comparison.py`
- `mypy examples/slow_objective_comparison.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8fe17cdc8320af455403ad46f214