### PR TITLE
Validate design space bounds

### DIFF
--- a/src/optilb/core.py
+++ b/src/optilb/core.py
@@ -20,6 +20,8 @@ class DesignSpace:
         object.__setattr__(self, "upper", np.asarray(self.upper, dtype=float))
         if self.lower.shape != self.upper.shape:
             raise ValueError("Lower and upper bounds must have the same shape")
+        if np.any(self.lower > self.upper):
+            raise ValueError("Lower bounds must not exceed upper bounds")
         if self.names is not None and len(self.names) != self.lower.size:
             raise ValueError("Number of names must match dimension")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,6 +4,7 @@ import pickle
 from datetime import datetime, timezone
 
 import numpy as np
+import pytest
 
 from optilb import Constraint, DesignPoint, DesignSpace, OptResult
 
@@ -16,6 +17,11 @@ def test_designspace_equality_and_pickle() -> None:
     assert ds1 == ds2
     ds3 = pickle.loads(pickle.dumps(ds1))
     assert ds1 == ds3
+
+
+def test_designspace_invalid_bounds() -> None:
+    with pytest.raises(ValueError, match="Lower bounds must not exceed upper bounds"):
+        DesignSpace(lower=[1.0, 0.0], upper=[0.0, 1.0])
 
 
 def test_designpoint_equality_and_pickle() -> None:


### PR DESCRIPTION
## Summary
- ensure `DesignSpace` checks lower bounds do not exceed upper bounds
- test invalid design space bounds raise `ValueError`

## Testing
- `flake8 src/optilb/core.py tests/test_core.py`
- `mypy src/optilb/core.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68906f3f5e6c83208a37436eb27215a0