### PR TITLE
task-XX: normalize MADS search space

### DIFF
--- a/docs/api/optimizers.md
+++ b/docs/api/optimizers.md
@@ -54,8 +54,13 @@ Using the `MADSOptimizer` requires the external `PyNomadBBO` package::
     ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
     obj = get_objective("quadratic")
     opt = MADSOptimizer()
-    result = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50)
+    result = opt.optimize(obj, np.array([1.0, 1.0]), ds, max_iter=50, normalize=True)
     print(result.best_x, result.best_f)
+
+Passing ``normalize=True`` maps the NOMAD search to the unit cube and
+unscales points before calling the objective or constraints.  Bounds must
+be finite and non-degenerate.  History and results are reported in the
+original coordinates.
 
 To evaluate poll/search points concurrently, construct the optimiser with a
 desired worker count and pass ``parallel=True``::
@@ -84,6 +89,7 @@ All optimisers that support parallel execution accept an ``n_workers`` keyword
 argument to limit the number of processes or threads used.  If omitted, the
 default is to utilise all available CPU cores.
 
-Setting ``normalize=True`` runs the algorithm in the unit cube and
-scales the inputs/outputs back afterwards.  This makes the default step
-size independent of the original parameter ranges.
+Both :class:`~optilb.optimizers.NelderMeadOptimizer` and
+:class:`~optilb.optimizers.MADSOptimizer` accept ``normalize=True`` to run in
+the unit hypercube and scale results back afterwards.  This makes default step
+sizes independent of the original parameter ranges.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Hardened MADS normalization: preserves constraint metadata, validates bounds early, records history in original space, and clears scaled history between runs.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,6 @@
+Changelog
+=========
+
+Unreleased
+----------
+- Hardened MADS normalization: preserves constraint metadata, validates bounds early, records history in original space, and clears scaled history between runs.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,4 +11,5 @@ optilb Documentation
    api/sampling
    api/objectives
    api/optimizers
+   changelog
 

--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -17,7 +17,7 @@ Built-in optimizers:
 
 - `BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives.
 - `NelderMeadOptimizer` – supports optional parallel evaluation and normalisation.
-- `MADSOptimizer` – binds to NOMAD's Mesh Adaptive Direct Search (requires PyNomadBBO).
+- `MADSOptimizer` – binds to NOMAD's Mesh Adaptive Direct Search (requires PyNomadBBO) and can normalise the search space with ``normalize=True`` (requires finite, non-degenerate bounds and reports results in the original coordinates).
 - `EarlyStopper` – utility to halt optimisation when progress stalls.
 
 All optimizers accept `n_workers` to control parallel execution where applicable.

--- a/docs/optimizers.rst
+++ b/docs/optimizers.rst
@@ -18,7 +18,7 @@ Available optimizers:
 
 * :class:`optilb.optimizers.BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives.
 * :class:`optilb.optimizers.NelderMeadOptimizer` – supports optional parallel evaluation and normalisation.
-* :class:`optilb.optimizers.MADSOptimizer` – interfaces with NOMAD's Mesh Adaptive Direct Search (requires ``PyNomadBBO``).
+* :class:`optilb.optimizers.MADSOptimizer` – interfaces with NOMAD's Mesh Adaptive Direct Search (requires ``PyNomadBBO``) and can normalise the search space with ``normalize=True`` (requires finite, non-degenerate bounds and reports results in the original coordinates).
 * :class:`optilb.optimizers.EarlyStopper` – utility to halt optimisation when progress stalls.
 
 All optimizers that support parallel execution accept an ``n_workers`` keyword to limit resource usage.

--- a/tests/test_optimizer_mads.py
+++ b/tests/test_optimizer_mads.py
@@ -22,7 +22,7 @@ def test_mads_quadratic_dims() -> None:
 
 
 def test_mads_plateau_cliff_constraint() -> None:
-    ds = DesignSpace(lower=[-2.0], upper=[2.0])
+    ds = DesignSpace(lower=np.array([-2.0]), upper=np.array([2.0]))
     obj = get_objective("plateau_cliff")
     cons = [Constraint(func=lambda x: x[0] - 0.0, name="x<=0")]
     opt = MADSOptimizer()
@@ -38,9 +38,91 @@ def test_mads_plateau_cliff_constraint() -> None:
 
 
 def test_mads_nfev() -> None:
-    ds = DesignSpace(lower=[-2.0], upper=[2.0])
+    ds = DesignSpace(lower=np.array([-2.0]), upper=np.array([2.0]))
     obj = get_objective("quadratic")
     opt = MADSOptimizer()
     res = opt.optimize(obj, np.array([1.0]), ds, max_iter=20)
     assert res.nfev == opt.nfev
     assert res.nfev >= len(res.history)
+
+
+def test_mads_normalize_smoke() -> None:
+    ds = DesignSpace(lower=np.array([-1000.0, -1.0]), upper=np.array([1000.0, 1.0]))
+    x0 = np.array([900.0, 0.8])
+
+    def anisotropic(x: np.ndarray) -> float:
+        return float(1e6 * x[0] ** 2 + x[1] ** 2)
+
+    opt1 = MADSOptimizer()
+    res1 = opt1.optimize(anisotropic, x0, ds, max_iter=40, seed=0)
+    opt2 = MADSOptimizer()
+    res2 = opt2.optimize(anisotropic, x0, ds, max_iter=40, seed=0, normalize=True)
+    assert res2.best_f <= res1.best_f + 1e-8
+    assert res2.nfev <= res1.nfev
+
+
+def test_mads_normalize_bounds_validation() -> None:
+    ds_inf = DesignSpace(lower=np.array([-np.inf]), upper=np.array([1.0]))
+    obj = get_objective("quadratic")
+    opt = MADSOptimizer()
+    with pytest.raises(
+        ValueError,
+        match="normalize=True requires finite, non-degenerate bounds for all variables",
+    ):
+        opt.optimize(obj, np.array([0.0]), ds_inf, max_iter=5, normalize=True)
+
+    ds_deg = DesignSpace(lower=np.array([0.0]), upper=np.array([0.0]))
+    with pytest.raises(
+        ValueError,
+        match="normalize=True requires finite, non-degenerate bounds for all variables",
+    ):
+        opt.optimize(obj, np.array([0.0]), ds_deg, max_iter=5, normalize=True)
+
+    ds_nan = DesignSpace(lower=np.array([0.0]), upper=np.array([np.nan]))
+    with pytest.raises(
+        ValueError,
+        match="normalize=True requires finite, non-degenerate bounds for all variables",
+    ):
+        opt.optimize(obj, np.array([0.0]), ds_nan, max_iter=5, normalize=True)
+
+
+def test_mads_normalize_mapping() -> None:
+    ds = DesignSpace(lower=np.array([-2.0, -4.0]), upper=np.array([2.0, 4.0]))
+    seen: list[np.ndarray] = []
+
+    def obj(x: np.ndarray) -> float:
+        seen.append(x.copy())
+        return float(np.sum(x**2))
+
+    opt = MADSOptimizer()
+    x0 = np.array([1.0, 2.0])
+    res = opt.optimize(obj, x0, ds, max_iter=20, normalize=True)
+    assert res.history[0].tag == "start"
+    np.testing.assert_allclose(res.history[0].x, x0)
+    assert np.all(res.best_x <= ds.upper) and np.all(res.best_x >= ds.lower)
+    for call in seen:
+        assert np.all(call <= ds.upper) and np.all(call >= ds.lower)
+    assert opt._history_scaled is not None
+    assert len(opt._history_scaled) == len(res.history) - 1
+    for u in opt._history_scaled:
+        assert np.all(u >= 0.0) and np.all(u <= 1.0)
+
+    # ensure scaled history is cleared on subsequent non-normalised runs
+    opt.optimize(obj, x0, ds, max_iter=5)
+    assert opt._history_scaled is None
+
+
+def test_mads_constraint_identity_metadata() -> None:
+    ds = DesignSpace(lower=np.array([-1.0]), upper=np.array([1.0]))
+    obj = get_objective("quadratic")
+
+    def cfunc(x: np.ndarray) -> bool:
+        return x[0] <= 0.0
+
+    con = Constraint(func=cfunc, name="c")
+    opt = MADSOptimizer()
+    opt.optimize(
+        obj, np.array([0.5]), ds, constraints=[con], max_iter=10, normalize=True
+    )
+    assert con.name == "c"
+    assert con.func is cfunc


### PR DESCRIPTION
## Summary
- harden MADS normalization with explicit bound validation, preserved constraint metadata, and robust history tracking
- document normalization requirements and add changelog entry
- expand tests for bounds errors, constraint identity, and state reset

## Testing
- `python -m isort src/optilb/optimizers/mads.py tests/test_optimizer_mads.py`
- `python -m black src/optilb/optimizers/mads.py tests/test_optimizer_mads.py`
- `python -m flake8 src/optilb/optimizers/mads.py tests/test_optimizer_mads.py`
- `python -m mypy src/optilb/optimizers/mads.py tests/test_optimizer_mads.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68919eea6e448320a74f0611eef9531a