### PR TITLE
Add normalised MADS variants to slow objective example

### DIFF
--- a/examples/slow_objective_comparison.py
+++ b/examples/slow_objective_comparison.py
@@ -139,6 +139,18 @@ def run_comparison() -> None:
             [
                 ("MADS", MADSOptimizer(n_workers=8), False, {}),
                 ("MADS (parallel)", MADSOptimizer(n_workers=8), True, {}),
+                (
+                    "MADS (normalised)",
+                    MADSOptimizer(n_workers=8),
+                    False,
+                    {"normalize": True},
+                ),
+                (
+                    "MADS (parallel, normalised)",
+                    MADSOptimizer(n_workers=8),
+                    True,
+                    {"normalize": True},
+                ),
             ]
         )
     else:  # pragma: no cover - optional dependency


### PR DESCRIPTION
## Summary
- add normalised and normalised parallel MADS variants to slow objective comparison example

## Testing
- `python -m isort examples/slow_objective_comparison.py`
- `python -m black examples/slow_objective_comparison.py`
- `python -m flake8 examples/slow_objective_comparison.py`
- `python -m mypy examples/slow_objective_comparison.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891a9ec3d64832089aea65ab83e6a3b