### PR TITLE
Fix centered Latin-Hypercube sampling

### DIFF
--- a/src/optilb/sampling/__init__.py
+++ b/src/optilb/sampling/__init__.py
@@ -37,14 +37,17 @@ def lhs(
     rng = np.random.default_rng(seed)
 
     if centered:
-        scramble = False
-
-    sampler = qmc.LatinHypercube(
-        d=design_space.dimension,
-        scramble=scramble,
-        rng=rng,
-    )
-    sample = sampler.random(n=sample_count)
+        sample = np.empty((sample_count, design_space.dimension))
+        for j in range(design_space.dimension):
+            perm = rng.permutation(sample_count)
+            sample[:, j] = (perm + 0.5) / sample_count
+    else:
+        sampler = qmc.LatinHypercube(
+            d=design_space.dimension,
+            scramble=scramble,
+            rng=rng,
+        )
+        sample = sampler.random(n=sample_count)
     scaled = qmc.scale(sample, design_space.lower, design_space.upper)
 
     # Round integers if bounds are integers


### PR DESCRIPTION
## Summary
- respect `centered` flag in Latin-Hypercube sampling by placing points at cell centers

## Testing
- `isort src/optilb/sampling/__init__.py`
- `black src/optilb/sampling/__init__.py`
- `flake8 src/optilb/sampling/__init__.py`
- `mypy src/optilb/sampling/__init__.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899b06af75083208a640b0c5f78a3b0