### PR TITLE
Add unit-space transform and normalize BFGS

### DIFF
--- a/docs/optimizers.md
+++ b/docs/optimizers.md
@@ -9,13 +9,14 @@ from optilb.optimizers import BFGSOptimizer
 ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
 obj = get_objective("quadratic")
 opt = BFGSOptimizer()
-res = opt.optimize(obj, ds.lower, ds)
+res = opt.optimize(obj, ds.lower, ds, normalize=True)
 print(res.best_x, res.best_f)
 ```
 
 Built-in optimizers:
 
-- `BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives.
+- `BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives and can
+  normalise the design space with `normalize=True`.
 - `NelderMeadOptimizer` – supports optional parallel evaluation and normalisation.
 - `MADSOptimizer` – binds to NOMAD's Mesh Adaptive Direct Search (requires PyNomadBBO) and can normalise the search space with ``normalize=True`` (requires finite, non-degenerate bounds and reports results in the original coordinates).
 - `EarlyStopper` – utility to halt optimisation when progress stalls.

--- a/docs/optimizers.rst
+++ b/docs/optimizers.rst
@@ -11,12 +11,12 @@ Example usage::
     ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
     obj = get_objective("quadratic")
     opt = BFGSOptimizer()
-    res = opt.optimize(obj, ds.lower, ds)
+    res = opt.optimize(obj, ds.lower, ds, normalize=True)
     print(res.best_x, res.best_f)
 
 Available optimizers:
 
-* :class:`optilb.optimizers.BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives.
+* :class:`optilb.optimizers.BFGSOptimizer` – wraps SciPy's L-BFGS-B for smooth objectives and can normalise the design space with ``normalize=True``.
 * :class:`optilb.optimizers.NelderMeadOptimizer` – supports optional parallel evaluation and normalisation.
 * :class:`optilb.optimizers.MADSOptimizer` – interfaces with NOMAD's Mesh Adaptive Direct Search (requires ``PyNomadBBO``) and can normalise the search space with ``normalize=True`` (requires finite, non-degenerate bounds and reports results in the original coordinates).
 * :class:`optilb.optimizers.EarlyStopper` – utility to halt optimisation when progress stalls.

--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -9,9 +9,10 @@ from typing import Callable, Sequence, cast
 import numpy as np
 from scipy import optimize
 
-from ..core import Constraint, DesignSpace, OptResult
+from ..core import Constraint, DesignPoint, DesignSpace, OptResult
 from .base import Optimizer
 from .early_stop import EarlyStopper
+from .utils import SpaceTransform
 
 logger = logging.getLogger("optilb")
 
@@ -67,11 +68,14 @@ class BFGSOptimizer(Optimizer):
         parallel: bool = False,
         verbose: bool = False,
         early_stopper: EarlyStopper | None = None,
+        normalize: bool = True,
     ) -> OptResult:
         """Run the optimiser.
 
         Parameters match :meth:`Optimizer.optimize`. Only bound constraints are
-        enforced.
+        enforced. When ``normalize=True``, optimisation happens in the unit
+        hypercube ``[0,1]^d`` and inputs/outputs are reported in the original
+        coordinates.
         """
         if seed is not None:
             np.random.default_rng(seed)  # for API symmetry; not used directly
@@ -81,9 +85,16 @@ class BFGSOptimizer(Optimizer):
                 "BFGSOptimizer ignores nonlinear constraints; only bounds are enforced"
             )
         self.reset_history()
-        self.record(x0, tag="start")
 
-        bounds = list(zip(space.lower, space.upper))
+        transform: SpaceTransform | None = None
+        if normalize:
+            transform = SpaceTransform(space)
+            x0 = transform.to_unit(x0)
+            bounds = [(0.0, 1.0)] * space.dimension
+        else:
+            bounds = list(zip(space.lower, space.upper))
+
+        self.record(x0, tag="start")
 
         jac: Callable[[np.ndarray], np.ndarray] | None = self.gradient
         if jac is None:
@@ -93,7 +104,14 @@ class BFGSOptimizer(Optimizer):
                     jac = maybe
                     break
 
-        wrapped_obj = self._wrap_objective(objective)
+        if transform is not None:
+
+            def obj_unit(u: np.ndarray) -> float:
+                return float(objective(transform.from_unit(u)))
+
+            wrapped_obj = self._wrap_objective(obj_unit)
+        else:
+            wrapped_obj = self._wrap_objective(objective)
 
         options: dict[str, float | int | bool] = {
             "maxiter": max_iter,
@@ -133,8 +151,12 @@ class BFGSOptimizer(Optimizer):
                 elif eps_vec.shape != (n,):
                     raise ValueError("fd_eps must be scalar or match dimension")
 
-            lower = np.asarray(space.lower, dtype=float)
-            upper = np.asarray(space.upper, dtype=float)
+            if transform is not None:
+                lower = np.zeros(n, dtype=float)
+                upper = np.ones(n, dtype=float)
+            else:
+                lower = np.asarray(space.lower, dtype=float)
+                upper = np.asarray(space.upper, dtype=float)
 
             def _central_grad(x: np.ndarray) -> np.ndarray:
                 x = np.asarray(x, dtype=float)
@@ -189,6 +211,16 @@ class BFGSOptimizer(Optimizer):
 
             jac = _central_grad
             use_central = True
+        elif transform is not None:
+            user_jac = jac
+
+            def _jac_unit(u: np.ndarray) -> np.ndarray:
+                return (
+                    np.asarray(user_jac(transform.from_unit(u)), dtype=float)
+                    * transform.span
+                )
+
+            jac = _jac_unit
 
         # ------------------------- optimisation --------------------------
         try:
@@ -213,6 +245,14 @@ class BFGSOptimizer(Optimizer):
             best_f = wrapped_obj.last_val
             if best_f is None:
                 best_f = float(wrapped_obj(best))
+            if transform is not None:
+                best = transform.from_unit(best)
+                self._history = [
+                    DesignPoint(
+                        x=transform.from_unit(pt.x), tag=pt.tag, timestamp=pt.timestamp
+                    )
+                    for pt in self._history
+                ]
             return OptResult(
                 best_x=best,
                 best_f=float(best_f),
@@ -223,8 +263,18 @@ class BFGSOptimizer(Optimizer):
         if res.status != 0:
             logger.warning("SciPy optimisation did not converge: %s", res.message)
 
+        best_x = res.x
+        if transform is not None:
+            best_x = transform.from_unit(best_x)
+            self._history = [
+                DesignPoint(
+                    x=transform.from_unit(pt.x), tag=pt.tag, timestamp=pt.timestamp
+                )
+                for pt in self._history
+            ]
+
         return OptResult(
-            best_x=res.x,
+            best_x=best_x,
             best_f=float(res.fun),
             history=self.history,
             nfev=self.nfev,

--- a/src/optilb/optimizers/utils/__init__.py
+++ b/src/optilb/optimizers/utils/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from .transform import SpaceTransform
+
+__all__ = ["SpaceTransform"]

--- a/src/optilb/optimizers/utils/transform.py
+++ b/src/optilb/optimizers/utils/transform.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import numpy as np
+
+from ...core import DesignSpace
+
+
+class SpaceTransform:
+    """Affine transform between original coordinates and [0,1]^d."""
+
+    def __init__(self, space: DesignSpace) -> None:
+        lower = np.asarray(space.lower, dtype=float)
+        upper = np.asarray(space.upper, dtype=float)
+        if lower.shape != upper.shape:
+            raise ValueError("DesignSpace lower/upper must have the same shape")
+        span = upper - lower
+        if not (np.all(np.isfinite(lower)) and np.all(np.isfinite(upper))):
+            raise ValueError("Normalization requires finite bounds")
+        if np.any(span <= 0.0):
+            raise ValueError(
+                "Normalization requires strictly positive span per dimension"
+            )
+        self.lower = lower
+        self.upper = upper
+        self.span = span
+
+    def to_unit(self, x: np.ndarray) -> np.ndarray:
+        x = np.asarray(x, dtype=float)
+        if x.shape != self.lower.shape:
+            raise ValueError("x has wrong dimension for SpaceTransform")
+        return (x - self.lower) / self.span
+
+    def from_unit(self, u: np.ndarray) -> np.ndarray:
+        u = np.asarray(u, dtype=float)
+        if u.shape != self.lower.shape:
+            raise ValueError("u has wrong dimension for SpaceTransform")
+        return self.lower + u * self.span

--- a/tests/test_bfgs_normalize.py
+++ b/tests/test_bfgs_normalize.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optilb import DesignSpace
+from optilb.optimizers import BFGSOptimizer
+
+
+def quadratic(x: np.ndarray) -> float:
+    return float(np.sum((x - 0.3) ** 2))
+
+
+def test_unit_space_noop() -> None:
+    ds = DesignSpace(lower=np.zeros(3), upper=np.ones(3))
+    x0 = np.array([0.8, 0.2, 0.5])
+    obj = quadratic
+
+    opt_raw = BFGSOptimizer()
+    res_raw = opt_raw.optimize(obj, x0, ds, normalize=False, max_iter=50)
+
+    opt_norm = BFGSOptimizer()
+    res_norm = opt_norm.optimize(obj, x0, ds, normalize=True, max_iter=50)
+
+    np.testing.assert_array_equal(res_raw.best_x, res_norm.best_x)
+    assert res_raw.best_f == res_norm.best_f
+    assert res_raw.nfev == res_norm.nfev
+    assert len(res_raw.history) == len(res_norm.history)
+    for a, b in zip(res_raw.history, res_norm.history):
+        np.testing.assert_array_equal(a.x, b.x)
+
+
+def test_history_in_original_units() -> None:
+    ds = DesignSpace(lower=np.array([5.0, 10.0]), upper=np.array([7.0, 12.0]))
+    x0 = np.array([5.5, 10.5])
+
+    def shifted_quad(x: np.ndarray) -> float:
+        return float(np.sum((x - np.array([6.0, 11.0])) ** 2))
+
+    opt = BFGSOptimizer()
+    res = opt.optimize(shifted_quad, x0, ds, normalize=True, max_iter=20)
+
+    np.testing.assert_array_equal(res.history[0].x, x0)
+    for pt in res.history:
+        assert np.all(pt.x >= ds.lower) and np.all(pt.x <= ds.upper)
+        assert np.all(pt.x > 1.0)

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from optilb.core import DesignSpace
+from optilb.optimizers.utils import SpaceTransform
+
+
+def test_round_trip() -> None:
+    rng = np.random.default_rng(0)
+    lower = rng.uniform(-5.0, 0.0, size=3)
+    upper = lower + rng.uniform(1.0, 5.0, size=3)
+    space = DesignSpace(lower=lower, upper=upper)
+    tf = SpaceTransform(space)
+    x = rng.uniform(lower, upper)
+    np.testing.assert_allclose(tf.from_unit(tf.to_unit(x)), x, atol=1e-15)
+
+
+def test_invalid_bounds() -> None:
+    space_inf = DesignSpace(lower=np.array([0.0, 0.0]), upper=np.array([1.0, np.inf]))
+    with pytest.raises(ValueError):
+        SpaceTransform(space_inf)
+    space_deg = DesignSpace(lower=np.array([0.0, 0.0]), upper=np.array([1.0, 0.0]))
+    with pytest.raises(ValueError):
+        SpaceTransform(space_deg)
+
+
+def test_identity_unit_space() -> None:
+    space = DesignSpace(lower=np.zeros(2), upper=np.ones(2))
+    tf = SpaceTransform(space)
+    x = np.array([0.3, 0.7])
+    np.testing.assert_array_equal(tf.to_unit(x), x)
+    np.testing.assert_array_equal(tf.from_unit(x), x)


### PR DESCRIPTION
## Summary
- add `SpaceTransform` for affine mapping to the unit hypercube
- normalize BFGS optimizer using `SpaceTransform` and report history in original units
- document normalization and add tests for transform and BFGS behavior

## Testing
- `flake8 src/optilb/optimizers/bfgs.py src/optilb/optimizers/utils/__init__.py src/optilb/optimizers/utils/transform.py tests/test_bfgs_normalize.py tests/test_transform.py`
- `mypy src/optilb/optimizers/bfgs.py src/optilb/optimizers/utils/transform.py tests/test_bfgs_normalize.py tests/test_transform.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b39df98b883208b9ef53894e42d4e