### PR TITLE
task-02: implement scale scheduler

### DIFF
--- a/src/optilb/runner/__init__.py
+++ b/src/optilb/runner/__init__.py
@@ -1,0 +1,7 @@
+"""Runner utilities."""
+
+from __future__ import annotations
+
+from .schedule import ScaleLevel, run_with_schedule
+
+__all__ = ["ScaleLevel", "run_with_schedule"]

--- a/src/optilb/runner/schedule.py
+++ b/src/optilb/runner/schedule.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, cast
+
+import numpy as np
+
+from ..core import DesignPoint, OptResult
+from ..optimizers.base import Optimizer
+from ..optimizers.early_stop import EarlyStopper
+
+
+@dataclass
+class ScaleLevel:
+    """Container for per-method scale settings."""
+
+    nm_step: float | Sequence[float]
+    mads_mesh: float
+    bfgs_eps_scale: float
+
+
+def _clone_early_stopper(es: EarlyStopper | None) -> EarlyStopper | None:
+    """Return a fresh copy of an :class:`EarlyStopper` instance."""
+
+    if es is None:
+        return None
+    return type(es)(
+        eps=es.eps,
+        patience=es.patience,
+        f_target=es.f_target,
+        time_limit=es.time_limit,
+        enabled=es.enabled,
+    )
+
+
+def run_with_schedule(
+    optimizer: Optimizer,
+    levels: List[ScaleLevel],
+    x0: np.ndarray,
+    budget_per_level: int,
+    **opt_kwargs: Any,
+) -> OptResult:
+    """Run *optimizer* through successive scale levels.
+
+    Parameters
+    ----------
+    optimizer:
+        Optimiser instance to run.
+    levels:
+        Ordered list of :class:`ScaleLevel` objects.
+    x0:
+        Starting point for the first level.
+    budget_per_level:
+        Maximum number of iterations allowed per level.
+    **opt_kwargs:
+        Additional keyword arguments forwarded to ``optimizer.optimize``.
+        Must include ``objective`` and ``space``.
+
+    Returns
+    -------
+    OptResult
+        Result containing the best design found, accumulated history and total
+        evaluation count across all levels.
+    """
+
+    from ..optimizers.bfgs import BFGSOptimizer
+    from ..optimizers.mads import MADSOptimizer
+    from ..optimizers.nelder_mead import NelderMeadOptimizer
+
+    incumbent_x = np.asarray(x0, dtype=float)
+    all_history: list[DesignPoint] = []
+    total_nfev = 0
+    best_x = incumbent_x.copy()
+    best_f = float("inf")
+
+    for lvl in levels:
+        lvl_kwargs: Dict[str, Any] = dict(opt_kwargs)
+        lvl_kwargs["max_iter"] = budget_per_level
+
+        base_eps: float | Sequence[float] | np.ndarray | None = lvl_kwargs.pop(
+            "fd_eps", None
+        )
+
+        if isinstance(optimizer, NelderMeadOptimizer):
+            optimizer.step = lvl.nm_step
+        elif isinstance(optimizer, MADSOptimizer):
+            if "initial_mesh" in inspect.signature(optimizer.optimize).parameters:
+                lvl_kwargs.setdefault("initial_mesh", lvl.mads_mesh)
+        elif isinstance(optimizer, BFGSOptimizer):
+            if base_eps is None:
+                base_eps = 1e-3
+            if np.isscalar(base_eps):
+                fd_eps: float | np.ndarray = float(cast(float, base_eps)) * float(
+                    lvl.bfgs_eps_scale
+                )
+            else:
+                arr = np.asarray(base_eps, dtype=float)
+                fd_eps = arr * float(lvl.bfgs_eps_scale)
+            optimizer.fd_eps = cast(float | Sequence[float], fd_eps)
+            if "fd_eps" in inspect.signature(optimizer.optimize).parameters:
+                lvl_kwargs["fd_eps"] = fd_eps
+
+        if "early_stopper" in lvl_kwargs:
+            lvl_kwargs["early_stopper"] = _clone_early_stopper(
+                lvl_kwargs["early_stopper"]
+            )
+
+        res = optimizer.optimize(
+            objective=lvl_kwargs.pop("objective"),
+            x0=incumbent_x,
+            space=lvl_kwargs.pop("space"),
+            constraints=lvl_kwargs.pop("constraints", ()),
+            **lvl_kwargs,
+        )
+
+        all_history.extend(res.history)
+        total_nfev += res.nfev
+        if res.best_f < best_f:
+            best_f = res.best_f
+            best_x = res.best_x
+        incumbent_x = res.best_x
+
+    return OptResult(
+        best_x=best_x,
+        best_f=best_f,
+        history=tuple(all_history),
+        nfev=total_nfev,
+    )

--- a/tests/test_runner_schedule.py
+++ b/tests/test_runner_schedule.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optilb.core import DesignSpace
+from optilb.optimizers import BFGSOptimizer, MADSOptimizer, NelderMeadOptimizer
+from optilb.runner import ScaleLevel, run_with_schedule
+
+levels = [
+    ScaleLevel(nm_step=0.2, mads_mesh=0.2, bfgs_eps_scale=0.5),
+    ScaleLevel(nm_step=0.1, mads_mesh=0.1, bfgs_eps_scale=0.25),
+    ScaleLevel(nm_step=0.05, mads_mesh=0.05, bfgs_eps_scale=0.125),
+]
+
+
+def bumpy(x: np.ndarray) -> float:
+    x = np.asarray(x, dtype=float)
+    rastrigin = 10 * x.size + np.sum(x**2 - 10 * np.cos(2 * np.pi * x))
+    bump = 0.05 * np.sin(50 * x[0]) * np.sin(50 * x[1])
+    return float(rastrigin + bump)
+
+
+def _best_per_level(res, obj):
+    bests: list[float] = []
+    current = None
+    for pt in res.history:
+        val = obj(pt.x)
+        if pt.tag == "start":
+            if current is not None:
+                bests.append(current)
+            current = val
+        else:
+            if current is None or val < current:
+                current = val
+    if current is not None:
+        bests.append(current)
+    return bests
+
+
+def test_schedule_nelder_mead() -> None:
+    ds = DesignSpace(lower=np.zeros(2), upper=np.ones(2))
+    x0 = np.array([0.8, 0.9])
+
+    opt = NelderMeadOptimizer()
+    res = run_with_schedule(
+        opt,
+        levels,
+        x0,
+        budget_per_level=50,
+        objective=bumpy,
+        space=ds,
+        normalize=True,
+        seed=0,
+    )
+    bests = _best_per_level(res, bumpy)
+    assert bests[1] <= bests[0]
+    assert bests[2] <= bests[1]
+    assert opt.step == levels[-1].nm_step
+
+    # expected nfev
+    opt_manual = NelderMeadOptimizer()
+    inc = x0.copy()
+    expected = 0
+    for lvl in levels:
+        opt_manual.step = lvl.nm_step
+        r = opt_manual.optimize(bumpy, inc, ds, max_iter=50, normalize=True, seed=0)
+        expected += r.nfev
+        inc = r.best_x
+    assert res.nfev == expected
+
+
+def test_schedule_mads() -> None:
+    ds = DesignSpace(lower=np.zeros(2), upper=np.ones(2))
+    x0 = np.array([0.8, 0.9])
+
+    opt = MADSOptimizer()
+    res = run_with_schedule(
+        opt,
+        levels,
+        x0,
+        budget_per_level=50,
+        objective=bumpy,
+        space=ds,
+        normalize=True,
+        seed=0,
+    )
+    bests = _best_per_level(res, bumpy)
+    assert bests[1] <= bests[0]
+    assert bests[2] <= bests[1]
+
+    opt_manual = MADSOptimizer()
+    inc = x0.copy()
+    expected = 0
+    for _lvl in levels:
+        r = opt_manual.optimize(bumpy, inc, ds, max_iter=50, normalize=True, seed=0)
+        expected += r.nfev
+        inc = r.best_x
+    assert res.nfev == expected
+
+
+def test_schedule_bfgs() -> None:
+    ds = DesignSpace(lower=np.zeros(2), upper=np.ones(2))
+    x0 = np.array([0.8, 0.9])
+
+    opt = BFGSOptimizer()
+    res = run_with_schedule(
+        opt,
+        levels,
+        x0,
+        budget_per_level=50,
+        objective=bumpy,
+        space=ds,
+        normalize=True,
+        seed=0,
+    )
+    bests = _best_per_level(res, bumpy)
+    assert bests[1] <= bests[0]
+    assert bests[2] <= bests[1]
+    assert np.allclose(np.asarray(opt.fd_eps), 1e-3 * levels[-1].bfgs_eps_scale)
+
+    opt_manual = BFGSOptimizer()
+    inc = x0.copy()
+    expected = 0
+    for lvl in levels:
+        opt_manual.fd_eps = 1e-3 * lvl.bfgs_eps_scale
+        r = opt_manual.optimize(bumpy, inc, ds, max_iter=50, normalize=True, seed=0)
+        expected += r.nfev
+        inc = r.best_x
+    assert res.nfev == expected


### PR DESCRIPTION
## Summary
- add `ScaleLevel` dataclass and `run_with_schedule` helper to manage coarse-to-fine optimization scales
- include smoke tests for Nelder–Mead, MADS and BFGS verifying monotone improvement and evaluation accounting

## Testing
- `python -m flake8 src/optilb/runner/schedule.py src/optilb/runner/__init__.py tests/test_runner_schedule.py`
- `python -m mypy src/optilb/runner/schedule.py src/optilb/runner/__init__.py tests/test_runner_schedule.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3f31000083208f13ca0738b7d5fa