### PR TITLE
Avoid deprecated SciPy L-BFGS-B options

### DIFF
--- a/src/optilb/optimizers/bfgs.py
+++ b/src/optilb/optimizers/bfgs.py
@@ -117,8 +117,10 @@ class BFGSOptimizer(Optimizer):
             "maxiter": max_iter,
             "ftol": tol,
             "gtol": tol,
-            "disp": verbose,
         }
+
+        if verbose:
+            logger.info("Starting L-BFGS-B optimisation with max_iter=%s", max_iter)
 
         if early_stopper is not None:
             early_stopper.reset()
@@ -259,6 +261,9 @@ class BFGSOptimizer(Optimizer):
                 history=self.history,
                 nfev=self.nfev,
             )
+
+        if verbose:
+            logger.info("SciPy optimisation finished: %s", res.message)
 
         if res.status != 0:
             logger.warning("SciPy optimisation did not converge: %s", res.message)


### PR DESCRIPTION
## Summary
- remove deprecated `disp` option in BFGS optimizer
- log optimisation start and end messages when `verbose=True`

## Testing
- `python -m isort src/optilb/optimizers/bfgs.py`
- `python -m black src/optilb/optimizers/bfgs.py`
- `python -m flake8 src/optilb/optimizers/bfgs.py`
- `python -m mypy src/optilb/optimizers/bfgs.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b42c36de4832097e931bf3326f0e1