### PR TITLE
Normalize optimizer runs in example script

### DIFF
--- a/examples/test.py
+++ b/examples/test.py
@@ -116,6 +116,7 @@ def run(name: str, optimizer, objective):
         max_iter=MAX_ITER,
         tol=1e-6,
         parallel=True,
+        normalize=True,
     )
     elapsed = time.perf_counter() - start
     results.append((name, res, elapsed))


### PR DESCRIPTION
## Summary
- ensure example optimization runs always operate in normalized space alongside parallel evaluation

## Testing
- `isort examples/test.py`
- `black examples/test.py`
- `flake8 examples/test.py`
- `mypy examples/test.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689da5ebffc883208d7802ec8a074c94