### PR TITLE
Fix mutability of DesignSpace names

### DIFF
--- a/src/optilb/core.py
+++ b/src/optilb/core.py
@@ -22,8 +22,11 @@ class DesignSpace:
             raise ValueError("Lower and upper bounds must have the same shape")
         if np.any(self.lower > self.upper):
             raise ValueError("Lower bounds must not exceed upper bounds")
-        if self.names is not None and len(self.names) != self.lower.size:
-            raise ValueError("Number of names must match dimension")
+        if self.names is not None:
+            names = tuple(self.names)
+            if len(names) != self.lower.size:
+                raise ValueError("Number of names must match dimension")
+            object.__setattr__(self, "names", names)
 
     @property
     def dimension(self) -> int:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,6 +24,13 @@ def test_designspace_invalid_bounds() -> None:
         DesignSpace(lower=[1.0, 0.0], upper=[0.0, 1.0])
 
 
+def test_designspace_names_are_immutable() -> None:
+    names = ["x", "y"]
+    ds = DesignSpace(lower=[0, 0], upper=[1, 1], names=names)
+    names[0] = "z"
+    assert ds.names == ("x", "y")
+
+
 def test_designpoint_equality_and_pickle() -> None:
     ts = datetime(2024, 1, 1, tzinfo=timezone.utc)
     p1 = DesignPoint(x=[0.5, 0.5], tag="foo", timestamp=ts)


### PR DESCRIPTION
## Summary
- safeguard DesignSpace names by storing them as an immutable tuple
- add regression test ensuring names cannot be mutated after creation

## Testing
- `isort src/optilb/core.py tests/test_core.py`
- `black src/optilb/core.py tests/test_core.py`
- `flake8 src/optilb/core.py tests/test_core.py`
- `mypy src/optilb/core.py`
- `pytest tests/test_core.py::test_designspace_names_are_immutable -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689db73bbf7c8320b4407c9d7b3654da