### PR TITLE
Document runner utilities and enforce immutable core arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # optilb
 
 **optilb** is an optimisation toolbox for low-dimensional shape tuning.  The
-roadmap combines Latin-Hypercube sampling with pluggable optimisers (Mesh
+project combines Latin-Hypercube sampling with pluggable optimisers (Mesh
 Adaptive Direct Search via PyNOMAD, SciPy's L-BFGS-B and a custom parallel
-Nelder–Mead).  CFD objectives—from analytic toy cases to external executables—are
-wrapped through a unified `OptimizationProblem` interface.  Optional
-Gaussian‑Process surrogates and robust optimisation utilities are scheduled for
-later milestones.
+Nelder–Mead).  Analytic toy objectives and lightweight surrogates are bundled
+for quick experimentation.  Gaussian‑Process surrogates and robust optimisation
+utilities are scheduled for later milestones.
 
 ## Installation
 
@@ -30,10 +29,14 @@ with a desired worker count and set ``parallel=True`` when calling
 
 `BFGSOptimizer` and `NelderMeadOptimizer` expose the same ``n_workers`` keyword
 to bound the number of threads or processes used for parallel finite
-difference/vertex evaluations.
+difference/vertex evaluations.  All optimisers accept an optional
+``EarlyStopper`` to terminate runs when progress stalls.  The
+``runner.run_with_schedule`` helper executes an optimiser across multiple scale
+levels.
 
-The current codebase provides the core data classes and a Latin-Hypercube
-sampler.  Below is a minimal example::
+The toolbox ships core data classes, analytic objectives, a Latin-Hypercube
+sampler and the optimisers mentioned above.  Below is a minimal sampling
+example::
 
     from optilb import DesignSpace
     from optilb.sampling import lhs

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ The documentation is written in both reStructuredText (.rst) and Markdown (.md) 
 * `sampling.rst`/`sampling.md` cover the Latin-Hypercube sampler.
 * `objectives.rst`/`objectives.md` document analytic objective functions.
 * `optimizers.rst`/`optimizers.md` describe built-in local optimizers.
+* `runner.rst`/`runner.md` illustrate scheduled optimisation runs.
 * `api/` contains API reference files mirroring these modules.
 
 The Sphinx build currently uses the `.rst` files, but Markdown copies are provided for quick browsing on GitHub.

--- a/docs/api/runner.md
+++ b/docs/api/runner.md
@@ -1,0 +1,13 @@
+# Runner API
+
+`optilb.runner` exposes two helpers:
+
+```python
+from optilb.runner import ScaleLevel, run_with_schedule
+```
+
+- `ScaleLevel` groups per-method scale settings.
+- `run_with_schedule` executes an optimiser through successive levels and
+  returns an `OptResult` containing the combined history.
+
+Refer to :doc:`../runner` for a complete example.

--- a/docs/api/runner.rst
+++ b/docs/api/runner.rst
@@ -1,0 +1,14 @@
+Runner API
+==========
+
+``optilb.runner`` exposes two helpers:
+
+.. code-block:: python
+
+    from optilb.runner import ScaleLevel, run_with_schedule
+
+- ``ScaleLevel`` groups per-method scale settings.
+- ``run_with_schedule`` executes an optimiser through successive levels and
+  returns an :class:`~optilb.OptResult` containing the combined history.
+
+Refer to :doc:`../runner` for a complete example.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -8,8 +8,10 @@ optilb Documentation
    sampling
    objectives
    optimizers
+   runner
    api/sampling
    api/objectives
    api/optimizers
+   api/runner
    changelog
 

--- a/docs/runner.md
+++ b/docs/runner.md
@@ -1,0 +1,33 @@
+# Scheduled Optimisation Runs
+
+The `optilb.runner` module provides utilities to execute an optimiser across
+multiple scale levels.  Each level can adapt step sizes or mesh parameters for
+individual optimisers.
+
+```python
+from optilb import DesignSpace, get_objective
+from optilb.optimizers import NelderMeadOptimizer
+from optilb.runner import ScaleLevel, run_with_schedule
+
+ds = DesignSpace(lower=[-2.0, -2.0], upper=[2.0, 2.0])
+obj = get_objective("quadratic")
+
+levels = [
+    ScaleLevel(nm_step=0.5, mads_mesh=0.5, bfgs_eps_scale=1.0),
+    ScaleLevel(nm_step=0.2, mads_mesh=0.2, bfgs_eps_scale=0.5),
+]
+
+opt = NelderMeadOptimizer()
+res = run_with_schedule(
+    opt,
+    levels,
+    x0=[1.0, 1.0],
+    budget_per_level=50,
+    objective=obj,
+    space=ds,
+)
+print(res.best_x, res.best_f)
+```
+
+`run_with_schedule` returns a combined `OptResult` with the best design found and
+the accumulated history.

--- a/docs/runner.rst
+++ b/docs/runner.rst
@@ -1,0 +1,34 @@
+Scheduled Optimisation Runs
+===========================
+
+The :mod:`optilb.runner` module provides utilities to execute an optimiser
+across multiple scale levels. Each level can adapt step sizes or mesh parameters
+for individual optimisers.
+
+.. code-block:: python
+
+    from optilb import DesignSpace, get_objective
+    from optilb.optimizers import NelderMeadOptimizer
+    from optilb.runner import ScaleLevel, run_with_schedule
+
+    ds = DesignSpace(lower=[-2.0, -2.0], upper=[2.0, 2.0])
+    obj = get_objective("quadratic")
+
+    levels = [
+        ScaleLevel(nm_step=0.5, mads_mesh=0.5, bfgs_eps_scale=1.0),
+        ScaleLevel(nm_step=0.2, mads_mesh=0.2, bfgs_eps_scale=0.5),
+    ]
+
+    opt = NelderMeadOptimizer()
+    res = run_with_schedule(
+        opt,
+        levels,
+        x0=[1.0, 1.0],
+        budget_per_level=50,
+        objective=obj,
+        space=ds,
+    )
+    print(res.best_x, res.best_f)
+
+``run_with_schedule`` returns a combined :class:`~optilb.OptResult` with the best
+design found and the accumulated history.


### PR DESCRIPTION
## Summary
- Make DesignSpace, DesignPoint and OptResult store read-only NumPy arrays
- Add runner documentation and API reference pages
- Refresh README and docs to describe current optimizers and scheduling helper

## Testing
- `flake8`
- `mypy --ignore-missing-imports src/optilb`
- `pytest -q`

Linked to `task-20` in ROADMAP.

------
https://chatgpt.com/codex/tasks/task_e_689dc50035a48320bce50050f4fb9015