### PR TITLE
feat: add unified optimization problem API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ difference/vertex evaluations.  All optimisers accept an optional
 ``runner.run_with_schedule`` helper executes an optimiser across multiple scale
 levels.
 
+For a higher‑level entry point that makes cross‑method comparisons easy,
+construct an :class:`OptimizationProblem`.  It accepts the objective, design
+space and initial point along with a chosen optimiser and common controls such
+as evaluation budgets and normalisation::
+
+    import numpy as np
+
+    from optilb import DesignSpace, OptimizationProblem, get_objective
+
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    prob = OptimizationProblem(obj, ds, np.array([3.0, 3.0]), optimizer="bfgs")
+    result = prob.run()
+    print(result.best_x, result.best_f, prob.log.nfev)
+
 The toolbox ships core data classes, analytic objectives, a Latin-Hypercube
 sampler and the optimisers mentioned above.  Below is a minimal sampling
 example::

--- a/docs/api/problem.md
+++ b/docs/api/problem.md
@@ -1,0 +1,17 @@
+# OptimizationProblem API
+
+`OptimizationProblem` orchestrates the optimisation run and exposes a small log
+structure for post‑analysis.
+
+```python
+from optilb import OptimizationProblem, DesignSpace, get_objective
+
+space = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+obj = get_objective("quadratic")
+problem = OptimizationProblem(obj, space, [3.0, 3.0], optimizer="bfgs")
+result = problem.run()
+print(problem.log.optimizer, problem.log.nfev)
+```
+
+The ``run`` method returns an :class:`OptResult` instance capturing the best
+point and evaluation history.

--- a/docs/api/problem.rst
+++ b/docs/api/problem.rst
@@ -1,0 +1,18 @@
+OptimizationProblem API
+=======================
+
+``OptimizationProblem`` orchestrates the optimisation run and exposes a small
+log structure for post‑analysis.
+
+.. code-block:: python
+
+    from optilb import OptimizationProblem, DesignSpace, get_objective
+
+    space = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    problem = OptimizationProblem(obj, space, [3.0, 3.0], optimizer="bfgs")
+    result = problem.run()
+    print(problem.log.optimizer, problem.log.nfev)
+
+The ``run`` method returns an :class:`OptResult` instance capturing the best
+point and evaluation history.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,11 @@ optilb Documentation
    objectives
    optimizers
    runner
+   problem
    api/sampling
    api/objectives
    api/optimizers
    api/runner
+   api/problem
    changelog
 

--- a/docs/problem.md
+++ b/docs/problem.md
@@ -1,0 +1,20 @@
+# Optimization Problem
+
+The `OptimizationProblem` class exposes a uniform façade over the available
+local optimisers.  It collects the objective, design space and initial point and
+runs the chosen optimiser while tracking run time and evaluation counts.  This
+makes side‑by‑side comparisons straightforward.
+
+```python
+import numpy as np
+from optilb import DesignSpace, OptimizationProblem, get_objective
+
+ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+obj = get_objective("quadratic")
+prob = OptimizationProblem(obj, ds, np.array([3.0, 3.0]), optimizer="nelder-mead")
+res = prob.run()
+print(res.best_x, res.best_f, prob.log.nfev)
+```
+
+The log accessible via `prob.log` records the optimizer name, wall‑clock runtime
+and whether early stopping was triggered.

--- a/docs/problem.rst
+++ b/docs/problem.rst
@@ -1,0 +1,21 @@
+Optimization Problem
+====================
+
+The ``OptimizationProblem`` class exposes a uniform façade over the available
+local optimisers.  It collects the objective, design space and initial point and
+runs the chosen optimiser while tracking run time and evaluation counts.  This
+makes side‑by‑side comparisons straightforward.
+
+.. code-block:: python
+
+    import numpy as np
+    from optilb import DesignSpace, OptimizationProblem, get_objective
+
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    prob = OptimizationProblem(obj, ds, np.array([3.0, 3.0]), optimizer="nelder-mead")
+    res = prob.run()
+    print(res.best_x, res.best_f, prob.log.nfev)
+
+The log accessible via ``prob.log`` records the optimizer name, wall‑clock
+runtime and whether early stopping was triggered.

--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -11,6 +11,7 @@ from .optimizers import (
     NelderMeadOptimizer,
     Optimizer,
 )
+from .problem import OptimizationLog, OptimizationProblem
 from .sampling import lhs
 
 __all__ = [
@@ -26,5 +27,7 @@ __all__ = [
     "EarlyStopper",
     "lhs",
     "get_objective",
+    "OptimizationProblem",
+    "OptimizationLog",
 ]
 __version__ = "0.0.0"

--- a/src/optilb/problem.py
+++ b/src/optilb/problem.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import inspect
+import logging
+from dataclasses import dataclass, field
+from time import perf_counter
+from typing import Any, Callable, Sequence
+
+import numpy as np
+
+from .core import Constraint, DesignSpace, OptResult
+from .optimizers import (
+    BFGSOptimizer,
+    EarlyStopper,
+    MADSOptimizer,
+    NelderMeadOptimizer,
+    Optimizer,
+)
+
+logger = logging.getLogger("optilb")
+
+
+@dataclass(slots=True)
+class OptimizationLog:
+    """Summary information for a completed optimisation run."""
+
+    optimizer: str
+    runtime: float
+    nfev: int
+    early_stopped: bool = False
+
+
+@dataclass(slots=True)
+class _EvalCap:
+    """Objective wrapper enforcing a maximum number of evaluations."""
+
+    func: Callable[[np.ndarray], float]
+    limit: int
+    calls: int = 0
+    best_f: float = field(default=float("inf"), init=False)
+    best_x: np.ndarray | None = field(default=None, init=False)
+
+    def __call__(self, x: np.ndarray) -> float:
+        if self.calls >= self.limit:
+            raise StopIteration
+        val = float(self.func(x))
+        self.calls += 1
+        if val < self.best_f:
+            self.best_f = val
+            self.best_x = np.asarray(x, dtype=float).copy()
+        return val
+
+
+class OptimizationProblem:
+    """Unified façade to run different local optimisers.
+
+    Parameters
+    ----------
+    objective:
+        Objective function returning a scalar value.
+    space:
+        Continuous design space defining variable bounds.
+    x0:
+        Starting point for the search.
+    optimizer:
+        Optimiser name or instance. Supported names are ``"bfgs"``,
+        ``"nelder-mead"`` and ``"mads"``. If an instance is provided it is
+        used directly.
+    constraints:
+        Optional sequence of constraints.
+    parallel:
+        Evaluate independent points concurrently where supported.
+    normalize:
+        Whether to operate in the unit hypercube when supported. ``None`` keeps
+        the optimiser's default.
+    max_iter, tol, seed:
+        Common optimisation controls forwarded to the underlying optimiser.
+    max_evals:
+        Hard cap on objective evaluations. When reached, the best known point is
+        returned and ``early_stopped`` is set in the log.
+    optimizer_options:
+        Keyword arguments used to construct the optimiser when *optimizer* is a
+        string identifier.
+    optimize_options:
+        Extra keyword arguments forwarded to ``optimizer.optimize``.
+    """
+
+    def __init__(
+        self,
+        objective: Callable[[np.ndarray], float],
+        space: DesignSpace,
+        x0: np.ndarray | Sequence[float],
+        *,
+        optimizer: str | Optimizer = "bfgs",
+        constraints: Sequence[Constraint] | None = None,
+        parallel: bool = False,
+        normalize: bool | None = None,
+        max_iter: int = 100,
+        tol: float = 1e-6,
+        seed: int | None = None,
+        max_evals: int | None = None,
+        early_stopper: EarlyStopper | None = None,
+        verbose: bool = False,
+        optimizer_options: dict[str, Any] | None = None,
+        optimize_options: dict[str, Any] | None = None,
+    ) -> None:
+        self.objective = objective
+        self.space = space
+        self.x0 = np.asarray(x0, dtype=float)
+        self.constraints = tuple(constraints or ())
+        self.parallel = parallel
+        self.normalize = normalize
+        self.max_iter = max_iter
+        self.tol = tol
+        self.seed = seed
+        self.max_evals = max_evals
+        self.early_stopper = early_stopper
+        self.verbose = verbose
+        self.optimize_options = dict(optimize_options or {})
+
+        opt_opts = dict(optimizer_options or {})
+        self.optimizer: Optimizer
+        if isinstance(optimizer, str):
+            key = optimizer.lower()
+            if key in {"bfgs", "lbfgsb", "l-bfgs-b"}:
+                self.optimizer = BFGSOptimizer(**opt_opts)
+            elif key in {"nelder-mead", "nm"}:
+                self.optimizer = NelderMeadOptimizer(**opt_opts)
+            elif key == "mads":
+                self.optimizer = MADSOptimizer(**opt_opts)
+            else:  # pragma: no cover - defensive
+                raise ValueError(f"Unknown optimizer '{optimizer}'")
+        else:
+            self.optimizer = optimizer
+            if opt_opts:
+                logger.warning(
+                    "optimizer_options ignored when optimizer is an instance"
+                )
+
+        self.log: OptimizationLog | None = None
+        self._result: OptResult | None = None
+
+    # ------------------------------------------------------------------
+    def _build_optimize_kwargs(self) -> dict[str, Any]:
+        sig = inspect.signature(self.optimizer.optimize)
+        kwargs: dict[str, Any] = {}
+        for name, value in {
+            "max_iter": self.max_iter,
+            "tol": self.tol,
+            "seed": self.seed,
+            "parallel": self.parallel,
+            "verbose": self.verbose,
+            "early_stopper": self.early_stopper,
+        }.items():
+            if name in sig.parameters:
+                kwargs[name] = value
+        if self.normalize is not None and "normalize" in sig.parameters:
+            kwargs["normalize"] = self.normalize
+        kwargs.update(self.optimize_options)
+        return kwargs
+
+    # ------------------------------------------------------------------
+    def run(self) -> OptResult:
+        """Execute the optimisation and return the result."""
+
+        kwargs = self._build_optimize_kwargs()
+        objective: Callable[[np.ndarray], float] = self.objective
+        capper: _EvalCap | None = None
+        if self.max_evals is not None:
+            capper = _EvalCap(objective, self.max_evals)
+            objective = capper
+
+        start = perf_counter()
+        early = False
+        try:
+            res = self.optimizer.optimize(
+                objective=objective,
+                x0=self.x0,
+                space=self.space,
+                constraints=self.constraints,
+                **kwargs,
+            )
+        except StopIteration:
+            early = True
+            assert capper is not None
+            best_x = capper.best_x
+            best_f = capper.best_f
+            if best_x is None:
+                best_x = np.asarray(self.x0, dtype=float)
+                best_f = float(self.objective(best_x))
+            self.optimizer.record(best_x, tag="cap")
+            res = OptResult(
+                best_x=best_x,
+                best_f=best_f,
+                history=self.optimizer.history,
+                nfev=self.optimizer.nfev,
+            )
+        runtime = perf_counter() - start
+        if (
+            self.early_stopper is not None
+            and len(self.optimizer.history) < self.max_iter
+        ):
+            early = True or early
+        self.log = OptimizationLog(
+            optimizer=type(self.optimizer).__name__,
+            runtime=runtime,
+            nfev=res.nfev,
+            early_stopped=early,
+        )
+        self._result = res
+        return res
+
+
+__all__ = ["OptimizationProblem", "OptimizationLog"]

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import numpy as np
+
+from optilb import DesignSpace, OptimizationProblem, get_objective
+
+
+def test_problem_bfgs() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    prob = OptimizationProblem(obj, ds, np.array([3.0, 3.0]), optimizer="bfgs")
+    res = prob.run()
+    np.testing.assert_allclose(res.best_x, np.zeros(2), atol=1e-5)
+    assert prob.log is not None
+    assert prob.log.nfev == res.nfev
+    assert prob.log.runtime >= 0.0
+
+
+def test_problem_eval_cap() -> None:
+    ds = DesignSpace(lower=[-5.0, -5.0], upper=[5.0, 5.0])
+    obj = get_objective("quadratic")
+    prob = OptimizationProblem(
+        obj,
+        ds,
+        np.array([3.0, 3.0]),
+        optimizer="nelder-mead",
+        max_evals=5,
+        max_iter=100,
+    )
+    res = prob.run()
+    assert prob.log is not None and prob.log.early_stopped
+    assert res.nfev <= 5


### PR DESCRIPTION
## Summary
- add `OptimizationProblem` facade for unified optimizer setup and run
- document unified API and export in package
- test optimisation problem wrapper

## Testing
- `python -m isort src tests docs`
- `python -m black src/optilb/problem.py`
- `python -m flake8`
- `python -m mypy src/optilb/problem.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dcaa085808320ba07d8fb3230a7c2