### PR TITLE
feat: add custom exceptions

### DIFF
--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
+from .exceptions import UnknownObjectiveError, UnknownOptimizerError
 from .objectives import get_objective
 from .optimizers import (
     BFGSOptimizer,
@@ -29,5 +30,7 @@ __all__ = [
     "get_objective",
     "OptimizationProblem",
     "OptimizationLog",
+    "UnknownObjectiveError",
+    "UnknownOptimizerError",
 ]
 __version__ = "0.0.0"

--- a/src/optilb/exceptions.py
+++ b/src/optilb/exceptions.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+"""Custom exception types used throughout the optilb package."""
+
+
+class UnknownObjectiveError(ValueError):
+    """Raised when an objective identifier is not recognised."""
+
+
+class UnknownOptimizerError(ValueError):
+    """Raised when an optimizer identifier is not recognised."""

--- a/src/optilb/objectives/__init__.py
+++ b/src/optilb/objectives/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 
 import numpy as np
 
+from ..exceptions import UnknownObjectiveError
 from .lbm_stub import lbm_stub
 
 
@@ -187,7 +188,7 @@ def get_objective(name: str, **kwargs: Any) -> Callable[[np.ndarray], float]:
         return plateau_cliff
     if key in {"lbm", "lbm_stub"}:
         return lbm_stub
-    raise ValueError(f"Unknown objective '{name}'")
+    raise UnknownObjectiveError(f"Unknown objective '{name}'")
 
 
 __all__ = [

--- a/src/optilb/problem.py
+++ b/src/optilb/problem.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Sequence
 import numpy as np
 
 from .core import Constraint, DesignSpace, OptResult
+from .exceptions import UnknownOptimizerError
 from .optimizers import (
     BFGSOptimizer,
     EarlyStopper,
@@ -129,7 +130,7 @@ class OptimizationProblem:
             elif key == "mads":
                 self.optimizer = MADSOptimizer(**opt_opts)
             else:  # pragma: no cover - defensive
-                raise ValueError(f"Unknown optimizer '{optimizer}'")
+                raise UnknownOptimizerError(f"Unknown optimizer '{optimizer}'")
         else:
             self.optimizer = optimizer
             if opt_opts:

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
+from optilb import UnknownObjectiveError
 from optilb.objectives import (
     get_objective,
     lbm_stub,
@@ -67,3 +69,8 @@ def test_get_objective_dispatch() -> None:
     assert callable(get_objective("spiky_sine"))
     assert callable(get_objective("checkerboard"))
     assert callable(get_objective("step_rastrigin"))
+
+
+def test_get_objective_unknown() -> None:
+    with pytest.raises(UnknownObjectiveError):
+        get_objective("does-not-exist")

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
-from optilb import DesignSpace, OptimizationProblem, get_objective
+from optilb import (
+    DesignSpace,
+    OptimizationProblem,
+    UnknownOptimizerError,
+    get_objective,
+)
 
 
 def test_problem_bfgs() -> None:
@@ -30,3 +36,10 @@ def test_problem_eval_cap() -> None:
     res = prob.run()
     assert prob.log is not None and prob.log.early_stopped
     assert res.nfev <= 5
+
+
+def test_unknown_optimizer() -> None:
+    ds = DesignSpace(lower=[-1.0, -1.0], upper=[1.0, 1.0])
+    obj = get_objective("quadratic")
+    with pytest.raises(UnknownOptimizerError):
+        OptimizationProblem(obj, ds, np.array([0.0, 0.0]), optimizer="foo")


### PR DESCRIPTION
## Summary
- add UnknownObjectiveError and UnknownOptimizerError
- use new exceptions for objective lookup and optimizer selection
- test error handling for bad names

## Testing
- `isort src/optilb/__init__.py src/optilb/objectives/__init__.py src/optilb/problem.py src/optilb/exceptions.py tests/test_objectives.py tests/test_optimization_problem.py`
- `black src/optilb/__init__.py src/optilb/objectives/__init__.py src/optilb/problem.py src/optilb/exceptions.py tests/test_objectives.py tests/test_optimization_problem.py`
- `flake8 src/optilb/__init__.py src/optilb/objectives/__init__.py src/optilb/problem.py src/optilb/exceptions.py tests/test_objectives.py tests/test_optimization_problem.py`
- `mypy src/optilb`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07685b54c8320b0f568cdfa6e27f4