### PR TITLE
docs: adopt google style docstrings

### DIFF
--- a/src/optilb/objectives/lbm_stub.py
+++ b/src/optilb/objectives/lbm_stub.py
@@ -15,25 +15,27 @@ def lbm_stub(
 ) -> float:
     """Lightweight surrogate for CFD cost.
 
-    This deterministic function mimics a multi-modal CFD response using
-    a sum of shifted Gaussians with additional sinusoidal perturbation.
+    This deterministic function mimics a multi-modal CFD response using a
+    sum of shifted Gaussians with additional sinusoidal perturbation.
 
-    Parameters
-    ----------
-    x:
-        Input vector.
-    sleep_ms:
-        Optional artificial delay in milliseconds to emulate wall time.
-    centers:
-        Locations of Gaussian peaks for each dimension.  If ``None``,
-        centers are placed evenly in ``[-0.5, 0.5]``.
-    width:
-        Standard deviation of each Gaussian peak.
+    Args:
+        x: Input vector.
+        sleep_ms: Optional artificial delay in milliseconds to emulate wall
+            time.
+        centers: Locations of Gaussian peaks for each dimension. If ``None``,
+            centers are placed evenly in ``[-0.5, 0.5]``.
+        width: Standard deviation of each Gaussian peak.
 
-    Returns
-    -------
-    float
-        Pseudo CFD objective value.
+    Returns:
+        float: Pseudo CFD objective value.
+
+    Raises:
+        ValueError: If the length of ``centers`` does not match ``x``.
+
+    Examples:
+        >>> import numpy as np
+        >>> lbm_stub(np.zeros(2))
+        0.0878...
     """
     arr = np.asarray(x, dtype=float)
     dim = arr.size

--- a/src/optilb/problem.py
+++ b/src/optilb/problem.py
@@ -54,35 +54,44 @@ class _EvalCap:
 class OptimizationProblem:
     """Unified façade to run different local optimisers.
 
-    Parameters
-    ----------
-    objective:
-        Objective function returning a scalar value.
-    space:
-        Continuous design space defining variable bounds.
-    x0:
-        Starting point for the search.
-    optimizer:
-        Optimiser name or instance. Supported names are ``"bfgs"``,
-        ``"nelder-mead"`` and ``"mads"``. If an instance is provided it is
-        used directly.
-    constraints:
-        Optional sequence of constraints.
-    parallel:
-        Evaluate independent points concurrently where supported.
-    normalize:
-        Whether to operate in the unit hypercube when supported. ``None`` keeps
-        the optimiser's default.
-    max_iter, tol, seed:
-        Common optimisation controls forwarded to the underlying optimiser.
-    max_evals:
-        Hard cap on objective evaluations. When reached, the best known point is
-        returned and ``early_stopped`` is set in the log.
-    optimizer_options:
-        Keyword arguments used to construct the optimiser when *optimizer* is a
-        string identifier.
-    optimize_options:
-        Extra keyword arguments forwarded to ``optimizer.optimize``.
+    Args:
+        objective: Objective function returning a scalar value.
+        space: Continuous design space defining variable bounds.
+        x0: Starting point for the search.
+        optimizer: Optimiser name or instance. Supported names are
+            ``"bfgs"``, ``"nelder-mead"`` and ``"mads"``. If an instance is
+            provided it is used directly.
+        constraints: Optional sequence of constraints.
+        parallel: Evaluate independent points concurrently where supported.
+        normalize: Whether to operate in the unit hypercube when supported.
+            ``None`` keeps the optimiser's default.
+        max_iter: Maximum number of iterations.
+        tol: Convergence tolerance.
+        seed: Random seed for reproducibility.
+        max_evals: Hard cap on objective evaluations. When reached, the best
+            known point is returned and ``early_stopped`` is set in the log.
+        early_stopper: Optional early stopping controller.
+        verbose: Emit progress information.
+        optimizer_options: Keyword arguments used to construct the optimiser
+            when ``optimizer`` is a string identifier.
+        optimize_options: Extra keyword arguments forwarded to
+            ``optimizer.optimize``.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If an unknown optimizer name is provided.
+
+    Examples:
+        >>> from optilb.core import DesignSpace
+        >>> def sphere(x):
+        ...     return float((x ** 2).sum())
+        >>> space = DesignSpace(lower=[-1, -1], upper=[1, 1])
+        >>> problem = OptimizationProblem(objective=sphere, space=space, x0=[0.5, 0.5])
+        >>> result = problem.run()
+        >>> result.best_x.round(1)
+        array([0., 0.])
     """
 
     def __init__(

--- a/src/optilb/runner/schedule.py
+++ b/src/optilb/runner/schedule.py
@@ -43,25 +43,34 @@ def run_with_schedule(
 ) -> OptResult:
     """Run *optimizer* through successive scale levels.
 
-    Parameters
-    ----------
-    optimizer:
-        Optimiser instance to run.
-    levels:
-        Ordered list of :class:`ScaleLevel` objects.
-    x0:
-        Starting point for the first level.
-    budget_per_level:
-        Maximum number of iterations allowed per level.
-    **opt_kwargs:
-        Additional keyword arguments forwarded to ``optimizer.optimize``.
-        Must include ``objective`` and ``space``.
+    Args:
+        optimizer: Optimiser instance to run.
+        levels: Ordered list of :class:`ScaleLevel` objects.
+        x0: Starting point for the first level.
+        budget_per_level: Maximum number of iterations allowed per level.
+        **opt_kwargs: Additional keyword arguments forwarded to
+            ``optimizer.optimize``. Must include ``objective`` and ``space``.
 
-    Returns
-    -------
-    OptResult
-        Result containing the best design found, accumulated history and total
-        evaluation count across all levels.
+    Returns:
+        OptResult: Result containing the best design found, accumulated history
+        and total evaluation count across all levels.
+
+    Raises:
+        ValueError: If ``levels`` is empty.
+
+    Examples:
+        >>> import numpy as np
+        >>> from optilb.core import DesignSpace
+        >>> from optilb.optimizers.nelder_mead import NelderMeadOptimizer
+        >>> levels = [ScaleLevel(nm_step=0.1, mads_mesh=1.0, bfgs_eps_scale=1.0)]
+        >>> def sphere(x):
+        ...     return float((x ** 2).sum())
+        >>> res = run_with_schedule(
+        ...     NelderMeadOptimizer(), levels, np.zeros(1), 5,
+        ...     objective=sphere, space=DesignSpace(lower=[-1], upper=[1])
+        ... )
+        >>> res.best_x.round(1)
+        array([0.])
     """
 
     from ..optimizers.bfgs import BFGSOptimizer

--- a/src/optilb/sampling/lhs.py
+++ b/src/optilb/sampling/lhs.py
@@ -16,23 +16,25 @@ def lhs(
 ) -> list[DesignPoint]:
     """Generate Latin-Hypercube samples.
 
-    Parameters
-    ----------
-    sample_count:
-        Number of design points to generate.
-    design_space:
-        Continuous design space describing bounds.
-    seed:
-        Random seed for reproducibility.
-    centered:
-        Place points at the center of each hypercube cell.
-    scramble:
-        Enable scrambling of the unit hypercube.
+    Args:
+        sample_count: Number of design points to generate.
+        design_space: Continuous design space describing bounds.
+        seed: Random seed for reproducibility.
+        centered: Place points at the center of each hypercube cell.
+        scramble: Enable scrambling of the unit hypercube.
 
-    Returns
-    -------
-    list[DesignPoint]
-        Generated design points scaled to ``design_space``.
+    Returns:
+        list[DesignPoint]: Generated design points scaled to ``design_space``.
+
+    Raises:
+        ValueError: If ``sample_count`` is not positive.
+
+    Examples:
+        >>> from optilb.core import DesignSpace
+        >>> space = DesignSpace(lower=[0, 0], upper=[1, 1])
+        >>> pts = lhs(2, space, seed=0)
+        >>> len(pts)
+        2
     """
     rng = np.random.default_rng(seed)
 


### PR DESCRIPTION
## Summary
- rewrite `lbm_stub` docstring using Google style with clear Args/Returns/Raises/Examples
- document `lhs` sampling function with Google-style sections
- clarify schedule runner and `OptimizationProblem` class docstrings

## Testing
- `isort src/optilb/objectives/lbm_stub.py src/optilb/sampling/lhs.py src/optilb/runner/schedule.py src/optilb/problem.py`
- `black src/optilb/objectives/lbm_stub.py src/optilb/sampling/lhs.py src/optilb/runner/schedule.py src/optilb/problem.py`
- `flake8 src/optilb/objectives/lbm_stub.py src/optilb/sampling/lhs.py src/optilb/runner/schedule.py src/optilb/problem.py`
- `mypy src/optilb/objectives/lbm_stub.py src/optilb/sampling/lhs.py src/optilb/runner/schedule.py src/optilb/problem.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a07685d2848320acd35076a3fbea00