### PR TITLE
task-03: round integer dims in-place for LHS

### DIFF
--- a/src/optilb/sampling/lhs.py
+++ b/src/optilb/sampling/lhs.py
@@ -51,10 +51,9 @@ def lhs(
     scaled = qmc.scale(sample, design_space.lower, design_space.upper)
 
     # Round integers if bounds are integers
-    rounded = scaled.copy()
     for i, (lo, hi) in enumerate(zip(design_space.lower, design_space.upper)):
         if float(lo).is_integer() and float(hi).is_integer():
-            rounded[:, i] = np.rint(rounded[:, i])
+            np.rint(scaled[:, i], out=scaled[:, i])
 
-    points = [DesignPoint(x=row) for row in rounded]
+    points = [DesignPoint(x=row) for row in scaled]
     return points

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
+from scipy.stats import qmc
 
 from optilb import DesignSpace
 from optilb.sampling import lhs
 
 
 def test_lhs_reproducible() -> None:
-    ds = DesignSpace(lower=[0.0, 0.0], upper=[1.0, 1.0])
+    ds = DesignSpace(lower=np.array([0.0, 0.0]), upper=np.array([1.0, 1.0]))
     pts1 = lhs(4, ds, seed=42)
     pts2 = lhs(4, ds, seed=42)
     arr1 = np.array([p.x for p in pts1])
@@ -16,7 +17,7 @@ def test_lhs_reproducible() -> None:
 
 
 def test_lhs_with_integer_dimension() -> None:
-    ds = DesignSpace(lower=[0, 0.0], upper=[10, 1.0])
+    ds = DesignSpace(lower=np.array([0, 0.0]), upper=np.array([10, 1.0]))
     pts = lhs(6, ds, seed=123)
     arr = np.array([p.x for p in pts])
     assert np.all(arr[:, 0] == np.round(arr[:, 0]))
@@ -24,8 +25,26 @@ def test_lhs_with_integer_dimension() -> None:
 
 
 def test_lhs_centered() -> None:
-    ds = DesignSpace(lower=[0.0], upper=[1.5])
+    ds = DesignSpace(lower=np.array([0.0]), upper=np.array([1.5]))
     pts = lhs(4, ds, centered=True, seed=0)
     arr = np.array([p.x for p in pts]).flatten()
     expected = np.array([0.1875, 0.5625, 0.9375, 1.3125])
     assert np.all(np.isin(arr, expected))
+
+
+def test_lhs_rounding_matches_previous() -> None:
+    ds = DesignSpace(lower=np.array([0, 0.0]), upper=np.array([10, 1.0]))
+    sample_count = 6
+    rng = np.random.default_rng(123)
+    sampler = qmc.LatinHypercube(d=ds.dimension, scramble=True, rng=rng)
+    sample = sampler.random(n=sample_count)
+    scaled = qmc.scale(sample, ds.lower, ds.upper)
+    rounded = scaled.copy()
+    for i, (lo, hi) in enumerate(zip(ds.lower, ds.upper)):
+        if float(lo).is_integer() and float(hi).is_integer():
+            rounded[:, i] = np.rint(rounded[:, i])
+
+    arr_expected = rounded
+    pts = lhs(sample_count, ds, seed=123)
+    arr = np.array([p.x for p in pts])
+    np.testing.assert_allclose(arr, arr_expected)


### PR DESCRIPTION
## Summary
- Round integer-bounded dimensions directly in the scaled LHS matrix to avoid unnecessary copies.
- Ensure LHS results match previous behaviour with a regression test.

## Testing
- `python -m isort src/optilb/sampling/lhs.py tests/test_sampling.py`
- `python -m black tests/test_sampling.py src/optilb/sampling/lhs.py`
- `python -m flake8 src/optilb/sampling/lhs.py tests/test_sampling.py`
- `python -m mypy src/optilb/sampling/lhs.py tests/test_sampling.py`
- `pytest -q`
- `python - <<'PY'
from optilb import DesignSpace
from optilb.sampling import lhs
from scipy.stats import qmc
import numpy as np
import timeit

nds = DesignSpace(lower=np.array([0, 0.0]), upper=np.array([10, 1.0]))


def baseline(sample_count: int, seed: int = 0):
    rng = np.random.default_rng(seed)
    sampler = qmc.LatinHypercube(d=nds.dimension, scramble=True, rng=rng)
    sample = sampler.random(n=sample_count)
    scaled = qmc.scale(sample, nds.lower, nds.upper)
    rounded = scaled.copy()
    for i, (lo, hi) in enumerate(zip(nds.lower, nds.upper)):
        if float(lo).is_integer() and float(hi).is_integer():
            rounded[:, i] = np.rint(rounded[:, i])
    return rounded


def new(sample_count: int, seed: int = 0):
    return np.array([p.x for p in lhs(sample_count, nds, seed=seed)])

print('lhs new', timeit.timeit(lambda: new(1000, 0), number=10))
print('baseline', timeit.timeit(lambda: baseline(1000, 0), number=10))

arr_new = new(6, 123)
arr_old = baseline(6, 123)
print('max diff', np.max(np.abs(arr_new - arr_old)))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a076873554832085568e6dbb79ecfe