### PR TITLE
feat: map objective names and add custom error

### DIFF
--- a/src/optilb/__init__.py
+++ b/src/optilb/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .core import Constraint, DesignPoint, DesignSpace, OptResult
+from .exceptions import UnknownObjectiveError
 from .objectives import get_objective
 from .optimizers import (
     BFGSOptimizer,
@@ -27,6 +28,7 @@ __all__ = [
     "EarlyStopper",
     "lhs",
     "get_objective",
+    "UnknownObjectiveError",
     "OptimizationProblem",
     "OptimizationLog",
 ]

--- a/src/optilb/exceptions.py
+++ b/src/optilb/exceptions.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+
+class UnknownObjectiveError(KeyError):
+    """Raised when an objective name is not recognised."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.name = name
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        return f"Unknown objective '{self.name}'"
+
+
+__all__ = ["UnknownObjectiveError"]

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
+from optilb.exceptions import UnknownObjectiveError
 from optilb.objectives import (
     get_objective,
     lbm_stub,
@@ -67,3 +69,8 @@ def test_get_objective_dispatch() -> None:
     assert callable(get_objective("spiky_sine"))
     assert callable(get_objective("checkerboard"))
     assert callable(get_objective("step_rastrigin"))
+
+
+def test_get_objective_unknown() -> None:
+    with pytest.raises(UnknownObjectiveError):
+        get_objective("does_not_exist")


### PR DESCRIPTION
## Summary
- replace get_objective if/elif with mapping lookup
- introduce UnknownObjectiveError for unknown objectives
- test objective retrieval failure case

## Testing
- `isort src/optilb/objectives/__init__.py src/optilb/exceptions.py src/optilb/__init__.py tests/test_objectives.py`
- `black src/optilb/objectives/__init__.py src/optilb/exceptions.py src/optilb/__init__.py tests/test_objectives.py`
- `flake8 src/optilb/objectives/__init__.py src/optilb/exceptions.py src/optilb/__init__.py tests/test_objectives.py`
- `mypy src/optilb/objectives/__init__.py src/optilb/exceptions.py src/optilb/__init__.py tests/test_objectives.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a076882df88320b692b218b550f56b