### PR TITLE
feat: map objective names to factories

### DIFF
--- a/src/optilb/objectives/__init__.py
+++ b/src/optilb/objectives/__init__.py
@@ -161,6 +161,20 @@ def make_step_rastrigin(
     return _StepRastrigin(sigma=sigma, seed=seed)
 
 
+_OBJECTIVES: dict[str, Callable[..., Callable[[np.ndarray], float]]] = {
+    "quadratic": lambda **_: quadratic_bowl,
+    "rastrigin": lambda **_: rastrigin,
+    "noisy_discontinuous": make_noisy_discontinuous,
+    "spiky_sine": make_spiky_sine,
+    "checkerboard": make_checkerboard,
+    "step_rastrigin": make_step_rastrigin,
+    "noisy_step_rastrigin": make_step_rastrigin,
+    "plateau_cliff": lambda **_: plateau_cliff,
+    "lbm": lambda **_: lbm_stub,
+    "lbm_stub": lambda **_: lbm_stub,
+}
+
+
 def get_objective(name: str, **kwargs: Any) -> Callable[[np.ndarray], float]:
     """Return an objective function by name.
 
@@ -172,23 +186,11 @@ def get_objective(name: str, **kwargs: Any) -> Callable[[np.ndarray], float]:
         Callable[[np.ndarray], float]: Objective function.
     """
     key = name.lower()
-    if key == "quadratic":
-        return quadratic_bowl
-    if key == "rastrigin":
-        return rastrigin
-    if key == "noisy_discontinuous":
-        return make_noisy_discontinuous(**kwargs)
-    if key == "spiky_sine":
-        return make_spiky_sine(**kwargs)
-    if key == "checkerboard":
-        return make_checkerboard(**kwargs)
-    if key in {"step_rastrigin", "noisy_step_rastrigin"}:
-        return make_step_rastrigin(**kwargs)
-    if key == "plateau_cliff":
-        return plateau_cliff
-    if key in {"lbm", "lbm_stub"}:
-        return lbm_stub
-    raise UnknownObjectiveError(f"Unknown objective '{name}'")
+    try:
+        factory = _OBJECTIVES[key]
+    except KeyError as err:
+        raise UnknownObjectiveError(f"Unknown objective '{name}'") from err
+    return factory(**kwargs)
 
 
 __all__ = [

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Callable
+
 import numpy as np
 import pytest
 
@@ -59,16 +61,34 @@ def test_step_rastrigin_floor() -> None:
     assert f(x) == expected
 
 
-def test_get_objective_dispatch() -> None:
-    f = get_objective("quadratic")
-    assert f(np.array([0.0])) == 0.0
-    f2 = get_objective("noisy_discontinuous", sigma=0.0)
-    assert f2(np.array([0.3])) == 0.0
-    f3 = get_objective("lbm_stub")
-    assert f3(np.array([0.1, 0.2])) == lbm_stub(np.array([0.1, 0.2]))
-    assert callable(get_objective("spiky_sine"))
-    assert callable(get_objective("checkerboard"))
-    assert callable(get_objective("step_rastrigin"))
+@pytest.mark.parametrize(
+    ("name", "expected"),
+    [
+        ("quadratic", quadratic_bowl),
+        ("rastrigin", rastrigin),
+        ("plateau_cliff", plateau_cliff),
+        ("lbm", lbm_stub),
+        ("lbm_stub", lbm_stub),
+    ],
+)
+def test_get_objective_dispatch(
+    name: str, expected: Callable[[np.ndarray], float]
+) -> None:
+    assert get_objective(name) is expected
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "noisy_discontinuous",
+        "spiky_sine",
+        "checkerboard",
+        "step_rastrigin",
+        "noisy_step_rastrigin",
+    ],
+)
+def test_get_objective_factory_dispatch(name: str) -> None:
+    assert callable(get_objective(name))
 
 
 def test_get_objective_unknown() -> None:


### PR DESCRIPTION
## Summary
- centralize objective lookup via `_OBJECTIVES` mapping
- simplify `get_objective` and raise `UnknownObjectiveError` on misses
- parameterize objective dispatch tests

## Testing
- `isort src/optilb/objectives/__init__.py tests/test_objectives.py`
- `black src/optilb/objectives/__init__.py tests/test_objectives.py`
- `flake8 src/optilb/objectives/__init__.py tests/test_objectives.py`
- `mypy src/optilb/objectives/__init__.py tests/test_objectives.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1a4e2eb508320aab2d2b981dcf45b